### PR TITLE
Unset command

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -65,7 +65,7 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 
 func addEnv(key string, value string, expand, replace, skipIfEmpty bool) error {
 	// Load envs, or create if not exist
-	envstore, err := envman.ReadEnvsOrCreateEmptyList()
+	envstore, err := envman.ReadOrInitEnvStore()
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func add(c *cli.Context) error {
 			}
 
 			if configs.EnvListBytesLimitInKB > 0 {
-				envList, err := envman.ReadEnvsOrCreateEmptyList()
+				envList, err := envman.ReadOrInitEnvStore()
 				if err != nil {
 					log.Fatalf("[ENVMAN] failed to get env list, error: %s", err)
 				}

--- a/cli/add.go
+++ b/cli/add.go
@@ -65,13 +65,13 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 
 func addEnv(key string, value string, expand, replace, skipIfEmpty bool) error {
 	// Load envs, or create if not exist
-	environments, err := envman.ReadEnvsOrCreateEmptyList()
+	envstore, err := envman.ReadEnvsOrCreateEmptyList()
 	if err != nil {
 		return err
 	}
 
 	// Validate input
-	validatedValue, err := validateEnv(key, value, environments.Envs)
+	validatedValue, err := validateEnv(key, value, envstore.Envs)
 	if err != nil {
 		return err
 	}
@@ -89,12 +89,12 @@ func addEnv(key string, value string, expand, replace, skipIfEmpty bool) error {
 		return err
 	}
 
-	newEnvSlice, err := envman.UpdateOrAddToEnvlist(environments.Envs, newEnv, replace)
+	newEnvSlice, err := envman.UpdateOrAddToEnvlist(envstore.Envs, newEnv, replace)
 	if err != nil {
 		return err
 	}
 
-	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, newEnvSlice, environments.Unsets)
+	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, newEnvSlice, envstore.Unsets)
 }
 
 func loadValueFromFile(pth string) (string, error) {

--- a/cli/add.go
+++ b/cli/add.go
@@ -44,6 +44,7 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 			log.Warnf("environment var (%s) value (%s...) too large", key, value[0:100])
 			log.Warnf("environment value size (%#v KB) - max allowed size: %#v KB", valueSizeInKB, (float64)(configs.EnvBytesLimitInKB))
 			return fmt.Sprintf("environment var (%s) value too large - rejected", key), nil
+
 		}
 	}
 

--- a/cli/add.go
+++ b/cli/add.go
@@ -71,7 +71,7 @@ func addEnv(key string, value string, expand, replace, skipIfEmpty bool) error {
 	}
 
 	// Validate input
-	validatedValue, err := validateEnv(key, value, environments)
+	validatedValue, err := validateEnv(key, value, environments.Envs)
 	if err != nil {
 		return err
 	}
@@ -89,12 +89,12 @@ func addEnv(key string, value string, expand, replace, skipIfEmpty bool) error {
 		return err
 	}
 
-	newEnvSlice, err := envman.UpdateOrAddToEnvlist(environments, newEnv, replace)
+	newEnvSlice, err := envman.UpdateOrAddToEnvlist(environments.Envs, newEnv, replace)
 	if err != nil {
 		return err
 	}
 
-	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, newEnvSlice)
+	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, newEnvSlice, environments.Unsets)
 }
 
 func loadValueFromFile(pth string) (string, error) {
@@ -113,10 +113,10 @@ func logEnvs() error {
 		return err
 	}
 
-	if len(environments) == 0 {
+	if len(environments.Envs) == 0 {
 		log.Info("[ENVMAN] Empty envstore")
 	} else {
-		for _, env := range environments {
+		for _, env := range environments.Envs {
 			key, value, err := env.GetKeyValuePair()
 			if err != nil {
 				return err
@@ -195,7 +195,7 @@ func add(c *cli.Context) error {
 				if err != nil {
 					log.Fatalf("[ENVMAN] failed to get env list, error: %s", err)
 				}
-				envListSizeInBytes, err := envListSizeInBytes(envList)
+				envListSizeInBytes, err := envListSizeInBytes(envList.Envs)
 				if err != nil {
 					log.Fatalf("[ENVMAN] failed to get env list size, error: %s", err)
 				}

--- a/cli/clear.go
+++ b/cli/clear.go
@@ -18,7 +18,7 @@ func clearEnvs() error {
 		return errors.New(errMsg)
 	}
 
-	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, []models.EnvironmentItemModel{})
+	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, []models.EnvironmentItemModel{}, []string{})
 }
 
 func clear(c *cli.Context) error {

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -68,5 +68,14 @@ var (
 			SkipFlagParsing: true,
 			Action:          run,
 		},
+		{
+			Name:    "unset",
+			Aliases: []string{"rm"},
+			Usage:   "Enlist an environment variable to be unset (for example to clear OS inherited vars for the process).",
+			Action:  unset,
+			Flags: []cli.Flag{
+				flKey,
+			},
+		},
 	}
 )

--- a/cli/print.go
+++ b/cli/print.go
@@ -72,7 +72,7 @@ func print(c *cli.Context) error {
 		log.Fatalf("Failed to read envs, error: %s", err)
 	}
 
-	envsJSONList, err := convertToEnsJSONModel(environments, expand)
+	envsJSONList, err := convertToEnsJSONModel(environments.Envs, expand)
 	if err != nil {
 		log.Fatalf("Failed to convert envs, error: %s", err)
 	}

--- a/cli/print_test.go
+++ b/cli/print_test.go
@@ -18,14 +18,14 @@ envs:
 	environments, err := envman.ParseEnvsYML([]byte(envsStr))
 	require.Equal(t, nil, err)
 
-	envsJSONList, err := convertToEnsJSONModel(environments, false)
+	envsJSONList, err := convertToEnsJSONModel(environments.Envs, false)
 	require.Equal(t, nil, err)
 	require.Equal(t, "$HOME", envsJSONList["TEST_HOME1"])
 	require.Equal(t, "$TEST_HOME1/test", envsJSONList["TEST_HOME2"])
 
 	testHome1 := os.Getenv("HOME")
 	testHome2 := path.Join(testHome1, "test")
-	envsJSONList, err = convertToEnsJSONModel(environments, true)
+	envsJSONList, err = convertToEnsJSONModel(environments.Envs, true)
 	require.Equal(t, nil, err)
 	require.Equal(t, testHome1, envsJSONList["TEST_HOME1"])
 	require.Equal(t, testHome2, envsJSONList["TEST_HOME2"])

--- a/cli/run.go
+++ b/cli/run.go
@@ -78,7 +78,7 @@ func run(c *cli.Context) error {
 
 		cmdToExecute := CommandModel{
 			Command:      doCommand,
-			Environments: doCmdEnvs,
+			Environments: doCmdEnvs.Envs,
 			Argumentums:  doArgs,
 		}
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -14,15 +14,15 @@ import (
 type CommandModel struct {
 	Command      string
 	Argumentums  []string
-	Environments []models.EnvironmentItemModel
+	Environments models.EnvsSerializeModel
 }
 
 func expandEnvsInString(inp string) string {
 	return os.ExpandEnv(inp)
 }
 
-func commandEnvs(envs []models.EnvironmentItemModel) ([]string, error) {
-	for _, env := range envs {
+func commandEnvs(envs models.EnvsSerializeModel) ([]string, error) {
+	for _, env := range envs.Envs {
 		key, value, err := env.GetKeyValuePair()
 		if err != nil {
 			return []string{}, err
@@ -48,6 +48,11 @@ func commandEnvs(envs []models.EnvironmentItemModel) ([]string, error) {
 			return []string{}, err
 		}
 	}
+
+	for _, key := range envs.Unsets {
+		os.Unsetenv(key)
+	}
+
 	return os.Environ(), nil
 }
 
@@ -78,7 +83,7 @@ func run(c *cli.Context) error {
 
 		cmdToExecute := CommandModel{
 			Command:      doCommand,
-			Environments: doCmdEnvs.Envs,
+			Environments: doCmdEnvs,
 			Argumentums:  doArgs,
 		}
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -12,9 +12,9 @@ import (
 
 // CommandModel ...
 type CommandModel struct {
-	Command      string
-	Argumentums  []string
-	Environments models.EnvsSerializeModel
+	Command     string
+	Argumentums []string
+	EnvStore    models.EnvsSerializeModel
 }
 
 func expandEnvsInString(inp string) string {
@@ -57,7 +57,7 @@ func commandEnvs(envs models.EnvsSerializeModel) ([]string, error) {
 }
 
 func runCommandModel(cmdModel CommandModel) (int, error) {
-	cmdEnvs, err := commandEnvs(cmdModel.Environments)
+	cmdEnvs, err := commandEnvs(cmdModel.EnvStore)
 	if err != nil {
 		return 1, err
 	}
@@ -69,7 +69,7 @@ func run(c *cli.Context) error {
 	log.Debug("[ENVMAN] - Work path:", envman.CurrentEnvStoreFilePath)
 
 	if len(c.Args()) > 0 {
-		doCmdEnvs, err := envman.ReadEnvs(envman.CurrentEnvStoreFilePath)
+		doEnvstore, err := envman.ReadEnvs(envman.CurrentEnvStoreFilePath)
 		if err != nil {
 			log.Fatal("[ENVMAN] - Failed to load EnvStore:", err)
 		}
@@ -82,9 +82,9 @@ func run(c *cli.Context) error {
 		}
 
 		cmdToExecute := CommandModel{
-			Command:      doCommand,
-			Environments: doCmdEnvs,
-			Argumentums:  doArgs,
+			Command:     doCommand,
+			EnvStore:    doEnvstore,
+			Argumentums: doArgs,
 		}
 
 		log.Debug("[ENVMAN] - Executing command:", cmdToExecute)

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -238,5 +239,21 @@ func TestCommandEnvs(t *testing.T) {
 			}
 		}
 		require.Equal(t, true, env3Found)
+	}
+
+	t.Log("unset OS envs test")
+	{
+		key := "TEST_ENV"
+		val := "test"
+		os.Setenv(key, val)
+		store := models.EnvsSerializeModel{Unsets: []string{key}}
+
+		envs, err := commandEnvs(store)
+		envFmt := "%s=%s" // note: if this format mismatches elements of `envs`, test can be a false positive!
+		unset := fmt.Sprintf(envFmt, key, val)
+
+		require.Equal(t, nil, err)
+		require.NotContains(t, envs, unset)
+
 	}
 }

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -38,8 +38,9 @@ func TestCommandEnvs(t *testing.T) {
 		require.Equal(t, nil, env2.FillMissingDefaults())
 
 		envs := []models.EnvironmentItemModel{env1, env2}
+		store := models.EnvsSerializeModel{Envs: envs}
 
-		sessionEnvs, err := commandEnvs(envs)
+		sessionEnvs, err := commandEnvs(store)
 		require.Equal(t, nil, err)
 
 		env1Found := false
@@ -80,8 +81,9 @@ func TestCommandEnvs(t *testing.T) {
 		require.Equal(t, nil, env2.FillMissingDefaults())
 
 		envs := []models.EnvironmentItemModel{env1, env2}
+		store := models.EnvsSerializeModel{Envs: envs}
 
-		sessionEnvs, err := commandEnvs(envs)
+		sessionEnvs, err := commandEnvs(store)
 		require.Equal(t, nil, err)
 
 		env1Found := false
@@ -124,8 +126,9 @@ func TestCommandEnvs(t *testing.T) {
 		require.Equal(t, nil, env2.FillMissingDefaults())
 
 		envs := []models.EnvironmentItemModel{env1, env2}
+		store := models.EnvsSerializeModel{Envs: envs}
 
-		sessionEnvs, err := commandEnvs(envs)
+		sessionEnvs, err := commandEnvs(store)
 		require.Equal(t, nil, err)
 
 		env1Found := false
@@ -168,8 +171,9 @@ func TestCommandEnvs(t *testing.T) {
 		require.Equal(t, nil, env2.FillMissingDefaults())
 
 		envs := []models.EnvironmentItemModel{env1, env2}
+		store := models.EnvsSerializeModel{Envs: envs}
 
-		sessionEnvs, err := commandEnvs(envs)
+		sessionEnvs, err := commandEnvs(store)
 		require.Equal(t, nil, err)
 
 		env1Found := false
@@ -214,8 +218,9 @@ func TestCommandEnvs(t *testing.T) {
 		require.Equal(t, nil, env3.FillMissingDefaults())
 
 		envs := []models.EnvironmentItemModel{env1, env2, env3}
+		store := models.EnvsSerializeModel{Envs: envs}
 
-		sessionEnvs, err := commandEnvs(envs)
+		sessionEnvs, err := commandEnvs(store)
 		require.Equal(t, nil, err)
 
 		env3Found := false

--- a/cli/unset.go
+++ b/cli/unset.go
@@ -8,7 +8,7 @@ import (
 func unset(c *cli.Context) error {
 	key := c.String(KeyKey)
 
-	envstore, err := envman.ReadEnvsOrCreateEmptyList()
+	envstore, err := envman.ReadOrInitEnvStore()
 	if err != nil {
 		return err
 	}

--- a/cli/unset.go
+++ b/cli/unset.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"github.com/bitrise-io/envman/envman"
+	"github.com/urfave/cli"
+)
+
+func unset(c *cli.Context) error {
+	key := c.String(KeyKey)
+
+	envstore, err := envman.ReadEnvsOrCreateEmptyList()
+	if err != nil {
+		return err
+	}
+
+	envstore.Unsets = append(envstore.Unsets, key)
+
+	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, envstore.Envs, envstore.Unsets)
+}

--- a/envman/util.go
+++ b/envman/util.go
@@ -241,8 +241,10 @@ func ReadEnvs(pth string) (models.EnvsSerializeModel, error) {
 	return ParseEnvsYML(bytes)
 }
 
-// ReadEnvsOrCreateEmptyList ...
-func ReadEnvsOrCreateEmptyList() (models.EnvsSerializeModel, error) {
+// ReadOrInitEnvStore reads from the system configured env store
+// file and returns the contents. If the file does not exist,
+// it creates an empty env store and returns that.
+func ReadOrInitEnvStore() (models.EnvsSerializeModel, error) {
 	envstore, err := ReadEnvs(CurrentEnvStoreFilePath)
 	if err != nil {
 		if err.Error() == "No environment variable list found" {

--- a/envman/util.go
+++ b/envman/util.go
@@ -219,16 +219,16 @@ func InitAtPath(pth string) error {
 
 // ParseEnvsYML ...
 func ParseEnvsYML(bytes []byte) (models.EnvsSerializeModel, error) {
-	var envsYML models.EnvsSerializeModel
-	if err := yaml.Unmarshal(bytes, &envsYML); err != nil {
+	var envstore models.EnvsSerializeModel
+	if err := yaml.Unmarshal(bytes, &envstore); err != nil {
 		return models.EnvsSerializeModel{}, err
 	}
-	for _, env := range envsYML.Envs {
+	for _, env := range envstore.Envs {
 		if err := env.NormalizeValidateFillDefaults(); err != nil {
 			return models.EnvsSerializeModel{}, err
 		}
 	}
-	return envsYML, nil
+	return envstore, nil
 }
 
 // ReadEnvs ...
@@ -243,7 +243,7 @@ func ReadEnvs(pth string) (models.EnvsSerializeModel, error) {
 
 // ReadEnvsOrCreateEmptyList ...
 func ReadEnvsOrCreateEmptyList() (models.EnvsSerializeModel, error) {
-	envModels, err := ReadEnvs(CurrentEnvStoreFilePath)
+	envstore, err := ReadEnvs(CurrentEnvStoreFilePath)
 	if err != nil {
 		if err.Error() == "No environment variable list found" {
 			err = InitAtPath(CurrentEnvStoreFilePath)
@@ -251,5 +251,5 @@ func ReadEnvsOrCreateEmptyList() (models.EnvsSerializeModel, error) {
 		}
 		return models.EnvsSerializeModel{}, err
 	}
-	return envModels, nil
+	return envstore, nil
 }

--- a/models/models.go
+++ b/models/models.go
@@ -24,7 +24,8 @@ type EnvironmentItemModel map[string]interface{}
 
 // EnvsSerializeModel ...
 type EnvsSerializeModel struct {
-	Envs []EnvironmentItemModel `json:"envs" yaml:"envs"`
+	Envs   []EnvironmentItemModel `json:"envs" yaml:"envs"`
+	Unsets []string               `json:"unsets" yaml:"unsets"`
 }
 
 // EnvsJSONListModel ...

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -406,6 +406,9 @@ func Test_EnvsSerializeModel_Normalize(t *testing.T) {
 - KEY_TWO: second value, with options
   opts:
     is_expand: true
+unsets:
+- ENV1
+- ENV2
 `
 	var objFromYAML EnvsSerializeModel
 	require.NoError(t, yaml.Unmarshal([]byte(yamlContent), &objFromYAML))
@@ -426,7 +429,7 @@ func Test_EnvsSerializeModel_Normalize(t *testing.T) {
 	{
 		jsonContBytes, err := json.Marshal(objFromYAML)
 		require.NoError(t, err)
-		require.Equal(t, `{"envs":[{"KEY_ONE":"first value","opts":{}},{"KEY_TWO":"second value, with options","opts":{"is_expand":true}}]}`, string(jsonContBytes))
+		require.Equal(t, `{"envs":[{"KEY_ONE":"first value","opts":{}},{"KEY_TWO":"second value, with options","opts":{"is_expand":true}}],"unsets":["ENV1","ENV2"]}`, string(jsonContBytes))
 	}
 
 	t.Log("test meta field")
@@ -437,6 +440,8 @@ func Test_EnvsSerializeModel_Normalize(t *testing.T) {
   opts:
     meta: 
       is_expose: true
+unsets:
+- ENV1
 `
 		var objFromYAML EnvsSerializeModel
 		require.NoError(t, yaml.Unmarshal([]byte(yamlContent), &objFromYAML))
@@ -457,7 +462,7 @@ func Test_EnvsSerializeModel_Normalize(t *testing.T) {
 		{
 			jsonContBytes, err := json.Marshal(objFromYAML)
 			require.NoError(t, err)
-			require.Equal(t, `{"envs":[{"KEY_ONE":"first value","opts":{}},{"KEY_TWO":"second value, with options","opts":{"meta":{"is_expose":true}}}]}`, string(jsonContBytes))
+			require.Equal(t, `{"envs":[{"KEY_ONE":"first value","opts":{}},{"KEY_TWO":"second value, with options","opts":{"meta":{"is_expose":true}}}],"unsets":["ENV1"]}`, string(jsonContBytes))
 
 			var serializeModel EnvsSerializeModel
 			require.NoError(t, yaml.Unmarshal([]byte(yamlContent), &serializeModel))


### PR DESCRIPTION
There are system exported ENVs, sometimes these need to be unset. 

An 'unset' command was implemented, which caused some models and signatures to change.

Identifiers were updated accordingly.