### PR TITLE
implement 'unset' subcommand

### DIFF
--- a/_tests/integration/unset_test.go
+++ b/_tests/integration/unset_test.go
@@ -1,0 +1,149 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/stretchr/testify/require"
+)
+
+func unsetCommand(key, envstore string) *command.Model {
+	return command.New(binPath(), "-p", envstore, "unset", "--key", key)
+}
+
+func runCommand(cmd, envstore string) *command.Model {
+	return command.New(binPath(), "-p", envstore, "run", cmd)
+}
+
+func TestUnset(t *testing.T) {
+	t.Log("only unset on an empty envstore")
+	{
+		// create a fully empty envstore
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("__envman__")
+		require.NoError(t, err)
+
+		envstore := filepath.Join(tmpDir, ".envstore")
+		f, err := os.Create(envstore)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		randomEnvKEY := "DONOTEXPORT"
+
+		// unset DONOTEXPORT env
+		out, err := unsetCommand(randomEnvKEY, envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// run env command through envman and see the exported env's list
+		out, err = runCommand("env", envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// check if the env is surely not exported
+		if strings.Contains(out, randomEnvKEY) {
+			t.Errorf("env is exported however it should be unset, complete list of exported envs:\n%s\n", out)
+		}
+	}
+
+	t.Log("add env then unset it in an empty envstore")
+	{
+		// create a fully empty envstore
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("__envman__")
+		require.NoError(t, err)
+
+		envstore := filepath.Join(tmpDir, ".envstore")
+		f, err := os.Create(envstore)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		randomEnvKEY := "DONOTEXPORT"
+
+		// add DONOTEXPORT env
+		out, err := addCommand(randomEnvKEY, "sample value", envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// unset DONOTEXPORT env
+		out, err = unsetCommand(randomEnvKEY, envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// run env command through envman and see the exported env's list
+		out, err = runCommand("env", envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// check if the env is surely not exported
+		if strings.Contains(out, randomEnvKEY) {
+			t.Errorf("env is exported however it should be unset, complete list of exported envs:\n%s\n", out)
+		}
+	}
+
+	t.Log("set env externally then only unset on an empty envstore")
+	{
+		// create a fully empty envstore
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("__envman__")
+		require.NoError(t, err)
+
+		envstore := filepath.Join(tmpDir, ".envstore")
+		f, err := os.Create(envstore)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		randomEnvKEY := "DONOTEXPORT"
+
+		require.NoError(t, os.Setenv(randomEnvKEY, "value"))
+
+		// unset DONOTEXPORT env
+		out, err := unsetCommand(randomEnvKEY, envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// run env command through envman and see the exported env's list
+		out, err = runCommand("env", envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// check if the env is surely not exported
+		if strings.Contains(out, randomEnvKEY) {
+			t.Errorf("env is exported however it should be unset, complete list of exported envs:\n%s\n", out)
+		}
+	}
+
+	t.Log("set env externally then add env then unset it in an empty envstore")
+	{
+		// create a fully empty envstore
+		tmpDir, err := pathutil.NormalizedOSTempDirPath("__envman__")
+		require.NoError(t, err)
+
+		envstore := filepath.Join(tmpDir, ".envstore")
+		f, err := os.Create(envstore)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		controlEnvKey := "EXPORT_THIS"
+		randomEnvKEY := "DONOTEXPORT"
+
+		require.NoError(t, os.Setenv(controlEnvKey, "value"))
+		require.NoError(t, os.Setenv(randomEnvKEY, "value"))
+
+		// add DONOTEXPORT env
+		out, err := addCommand(randomEnvKEY, "sample value", envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// unset DONOTEXPORT env
+		out, err = unsetCommand(randomEnvKEY, envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// run env command through envman and see the exported env's list
+		out, err = runCommand("env", envstore).RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+
+		// check if the env is surely not exported
+		if !strings.Contains(out, controlEnvKey) {
+			t.Errorf("env %s is not exported, complete list of exported envs:\n%s\n", controlEnvKey, out)
+		}
+
+		// check if the env is surely not exported
+		if strings.Contains(out, randomEnvKEY) {
+			t.Errorf("env is exported however it should be unset, complete list of exported envs:\n%s\n", out)
+		}
+	}
+}

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -68,5 +68,14 @@ var (
 			SkipFlagParsing: true,
 			Action:          run,
 		},
+		{
+			Name:    "unset",
+			Aliases: []string{"rm"},
+			Usage:   "Enlist an environment variable to be unset (for example to clear OS inherited vars for the process).",
+			Action:  unset,
+			Flags: []cli.Flag{
+				flKey,
+			},
+		},
 	}
 )

--- a/cli/run.go
+++ b/cli/run.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
@@ -31,6 +32,13 @@ func commandEnvs(envs []models.EnvironmentItemModel) ([]string, error) {
 		opts, err := env.GetOptions()
 		if err != nil {
 			return []string{}, err
+		}
+
+		if opts.Unset != nil && *opts.Unset {
+			if err := os.Unsetenv(key); err != nil {
+				return []string{}, fmt.Errorf("unset env (%s): %s", key, err)
+			}
+			continue
 		}
 
 		if *opts.SkipIfEmpty && value == "" {

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -233,5 +234,35 @@ func TestCommandEnvs(t *testing.T) {
 			}
 		}
 		require.Equal(t, true, env3Found)
+	}
+
+	t.Log("unset OS envs test")
+	{
+		// given
+		key := "TEST_ENV"
+		val := "test"
+		if err := os.Setenv(key, val); err != nil {
+			require.Equal(t, nil, err, "test setup: error seting env (%s=%s)", key, val)
+		}
+		env := models.EnvironmentItemModel{
+			key: val,
+			models.OptionsKey: models.EnvironmentItemOptionsModel{
+				Unset: pointers.NewBoolPtr(true),
+			},
+		}
+		require.Equal(t, nil, env.FillMissingDefaults())
+		testEnvs := []models.EnvironmentItemModel{
+			env,
+		}
+
+		// when
+		envs, err := commandEnvs(testEnvs)
+		envFmt := "%s=%s" // note: if this format mismatches elements of `envs`, test can be a false positive!
+		unset := fmt.Sprintf(envFmt, key, val)
+
+		// then
+		require.Equal(t, nil, err)
+		require.NotContains(t, envs, unset, "failed to unset env (%s)", key)
+
 	}
 }

--- a/cli/unset.go
+++ b/cli/unset.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"github.com/bitrise-io/envman/envman"
+	"github.com/bitrise-io/envman/models"
+	"github.com/bitrise-io/go-utils/pointers"
+	"github.com/urfave/cli"
+)
+
+func unset(c *cli.Context) error {
+	key := c.String(KeyKey)
+	// Load envs, or create if not exist
+	environments, err := envman.ReadEnvsOrCreateEmptyList()
+	if err != nil {
+		return err
+	}
+
+	// Add or update envlist
+	newEnv := models.EnvironmentItemModel{
+		key: "",
+		models.OptionsKey: models.EnvironmentItemOptionsModel{
+			Unset: pointers.NewBoolPtr(true),
+		},
+	}
+
+	if err := newEnv.NormalizeValidateFillDefaults(); err != nil {
+		return err
+	}
+
+	newEnvSlice, err := envman.UpdateOrAddToEnvlist(environments, newEnv, true)
+	if err != nil {
+		return err
+	}
+
+	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, newEnvSlice)
+}

--- a/envman/util.go
+++ b/envman/util.go
@@ -119,6 +119,9 @@ func removeDefaults(env *models.EnvironmentItemModel) error {
 	if opts.SkipIfEmpty != nil && *opts.SkipIfEmpty == models.DefaultSkipIfEmpty {
 		opts.SkipIfEmpty = nil
 	}
+	if opts.Unset != nil && *opts.Unset == models.DefaultUnset {
+		opts.Unset = nil
+	}
 
 	(*env)[models.OptionsKey] = opts
 	return nil
@@ -166,6 +169,9 @@ func generateFormattedYMLForEnvModels(envs []models.EnvironmentItemModel) (model
 			hasOptions = true
 		}
 		if opts.SkipIfEmpty != nil {
+			hasOptions = true
+		}
+		if opts.Unset != nil {
 			hasOptions = true
 		}
 

--- a/models/models.go
+++ b/models/models.go
@@ -15,6 +15,7 @@ type EnvironmentItemOptionsModel struct {
 	IsDontChangeValue *bool    `json:"is_dont_change_value,omitempty" yaml:"is_dont_change_value,omitempty"`
 	IsTemplate        *bool    `json:"is_template,omitempty" yaml:"is_template,omitempty"`
 	IsSensitive       *bool    `json:"is_sensitive,omitempty" yaml:"is_sensitive,omitempty"`
+	Unset             *bool    `json:"unset,omitempty" yaml:"unset,omitempty"`
 	//
 	Meta map[string]interface{} `json:"meta,omitempty" yaml:"meta,omitempty"`
 }

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -29,6 +29,8 @@ const (
 	DefaultIsDontChangeValue = false
 	// DefaultIsTemplate ...
 	DefaultIsTemplate = false
+	// DefaultUnset ...
+	DefaultUnset = false
 )
 
 // NewEnvJSONList ...
@@ -294,6 +296,10 @@ func (env *EnvironmentItemModel) FillMissingDefaults() error {
 	if options.Meta == nil {
 		options.Meta = map[string]interface{}{}
 	}
+	if options.Unset == nil {
+		options.Unset = pointers.NewBoolPtr(false)
+	}
+
 	(*env)[OptionsKey] = options
 	return nil
 }

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -171,6 +171,12 @@ func (envSerModel *EnvironmentItemOptionsModel) ParseFromInterfaceMap(input map[
 				return fmt.Errorf("failed to parse bool value (%#v) for key (%s)", value, keyStr)
 			}
 			envSerModel.SkipIfEmpty = castedBoolPtr
+		case "unset":
+			castedBoolPtr, ok := parseutil.CastToBoolPtr(value)
+			if !ok {
+				return fmt.Errorf("failed to parse bool value (%#v) for key (%s)", value, keyStr)
+			}
+			envSerModel.Unset = castedBoolPtr
 		case "meta":
 			castedMapStringInterface, ok := parseutil.CastToMapStringInterface(value)
 			if !ok {

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -303,7 +303,7 @@ func (env *EnvironmentItemModel) FillMissingDefaults() error {
 		options.Meta = map[string]interface{}{}
 	}
 	if options.Unset == nil {
-		options.Unset = pointers.NewBoolPtr(false)
+		options.Unset = pointers.NewBoolPtr(DefaultUnset)
 	}
 
 	(*env)[OptionsKey] = options


### PR DESCRIPTION
There are system exported ENVs, sometimes these need to be unset.