### PR TITLE
Update BITRISE_CLI_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 ENV PROJ_NAME envman
-ENV BITRISE_CLI_VERSION 1.21.0
+ENV BITRISE_CLI_VERSION 1.38.0
 ENV GO_VERSION go1.10.3.linux-amd64.tar.gz
 
 RUN apt-get update


### PR DESCRIPTION
https://github.com/bitrise-io/bitrise/releases/download/1.21.0/bitrise-Linux-x86_64 no longer exists, so `docker build -t envman .` now fails.
```
Step 7/20 : RUN curl -L https://github.com/bitrise-io/bitrise/releases/download/$BITRISE_CLI_VERSION/bitrise-$(uname -s)-$(uname -m) > /usr/local/bin/bitrise
 ---> Using cache
 ---> 55f054895e88
Step 8/20 : RUN chmod +x /usr/local/bin/bitrise
 ---> Using cache
 ---> 63c62e357ec5
Step 9/20 : RUN ls /usr/local/bin
 ---> Running in 47b34fdef380
bitrise
Removing intermediate container 47b34fdef380
 ---> 6186ef22df8c
Step 10/20 : RUN bitrise setup
 ---> Running in 86c5f19dcb05
/usr/local/bin/bitrise: 1: /usr/local/bin/bitrise: Not: not found
```