### PR TITLE
Build for Apple Silicon

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
             echo "Create final binaries"
             echo "  Build number: $BITRISE_BUILD_NUMBER"
 
-            export ARCH=x86_64
+            export ARCH=arm64
             export GOARCH=amd64
 
             # Create Darwin bin
@@ -70,22 +70,6 @@ workflows:
             envman add --key OSX_DEPLOY_PATH --value $DEPLOY_PATH
             cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
             echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
-
-
-            # Create Linux binary
-            export OS=Linux
-            export GOOS=linux
-
-            DEPLOY_PATH="_bin/$BIN_NAME-$OS-$ARCH"
-            echo "  Create final Linux binary at: $DEPLOY_PATH"
-
-            go build \
-              -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
-              -o "$DEPLOY_PATH"
-
-            envman add --key LINUX_DEPLOY_PATH --value $DEPLOY_PATH
-            cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
-            echo "  Copy final Linux binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
 
   dep-update:
     title: Dep update

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -61,6 +61,8 @@ workflows:
             export OS=Darwin
             export GOOS=darwin
 
+            go get github.com/bitrise-io/envman/cli
+
             DEPLOY_PATH="_bin/$BIN_NAME-$OS-$ARCH"
             echo "  Create final Darwin binary at: $DEPLOY_PATH"
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,6 +40,9 @@ workflows:
   create-binaries:
     title: Create binaries
     steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@4: {}
     - script:
         title: Create binaries
         inputs:
@@ -81,8 +84,5 @@ workflows:
             #!/bin/bash
             set -ex
             go get -u -v github.com/golang/dep/cmd/dep
-            echo "hi"
-            pwd
-            ls
             dep ensure -v
             dep ensure -v -update

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -81,6 +81,8 @@ workflows:
             #!/bin/bash
             set -ex
             go get -u -v github.com/golang/dep/cmd/dep
+            echo "hi"
+            pwd
             ls
             dep ensure -v
             dep ensure -v -update

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -81,5 +81,6 @@ workflows:
             #!/bin/bash
             set -ex
             go get -u -v github.com/golang/dep/cmd/dep
+            ls
             dep ensure -v
             dep ensure -v -update

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -75,6 +75,7 @@ workflows:
             envman add --key OSX_DEPLOY_PATH --value $DEPLOY_PATH
             cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
             echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
+    - deploy-to-bitrise-io@1: {}
 
   dep-update:
     title: Dep update

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -37,34 +37,21 @@ workflows:
             unset content
             go test -v ./_tests/integration/...
 
-  create-binaries:
-    title: Create binaries
+  _create-binary:
+    title: creates binary for specified platform
     steps:
-    - activate-ssh-key@4:
-        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
     - script:
-        title: Create binaries
+        title: Create binary
         inputs:
         - content: |
             #!/bin/bash
             set -ex
 
-            echo
-            echo "Create final binaries"
+            echo "  Create binary for $DESCRIPTION"
             echo "  Build number: $BITRISE_BUILD_NUMBER"
 
-            export ARCH=arm64
-            export GOARCH=amd64
-
-            # Create Darwin bin
-            export OS=Darwin
-            export GOOS=darwin
-
-            go get github.com/bitrise-io/envman/cli
-
             DEPLOY_PATH="_bin/$BIN_NAME-$OS-$ARCH"
-            echo "  Create final Darwin binary at: $DEPLOY_PATH"
+            echo "  Create at: $DEPLOY_PATH"
 
             version_package="github.com/bitrise-io/envman/version"
 
@@ -72,11 +59,46 @@ workflows:
               -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
               -o "$DEPLOY_PATH"
 
-            envman add --key OSX_DEPLOY_PATH --value $DEPLOY_PATH
             cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
-            echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
-    - deploy-to-bitrise-io@1: {}
+            echo "  Copy binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
 
+  create-x86-darwin-binary:
+    after_run:
+    - _create-binary
+    envs:
+    - DESCRIPTION: "x86 Darwin"
+    - ARCH: "x86_64"
+    - GOARCH: "amd64"
+    - OS: "Darwin"
+    - GOOS: "darwin"
+
+  create-arm-darwin-binary:
+    after_run:
+    - _create-binary
+    envs:
+    - DESCRIPTION: "ARM Darwin"
+    - ARCH: "arm64"
+    - GOARCH: "amd64"
+    - OS: "Darwin"
+    - GOOS: "darwin"
+
+  create-x86-linux-binary:
+    after_run:
+    - _create-binary
+    envs:
+    - DESCRIPTION: "x86 Linux"
+    - ARCH: "x86_64"
+    - GOARCH: "amd64"
+    - OS: "Linux"
+    - GOOS: "linux"
+
+  create-binaries:
+    title: Create binaries
+    before_run:
+    - create-arm-darwin-binary
+    - create-x86-darwin-binary
+    - create-x86-linux-binary
+  
   dep-update:
     title: Dep update
     steps:


### PR DESCRIPTION
Building Stepman and Envman for ARM on Mac are prerequisites to the bitrise cli supporting the new M1 machines. This is a near clone of the associated stepman PR (https://github.com/bitrise-io/stepman/pull/298).

This PR contains some re-organization of the bitrise.yml to reduce copy-paste, but the actual change is quite small. It simply adds an ARM/Darwin build target to the create-binaries workflow.

Please let me know if my changes are not consistent with how envman is typically built and deployed. I had trouble running the bitrise.yml as written. My other stepman branch, [m1_testing](https://github.com/benbitrise/stepman/compare/master...benbitrise:m1_testing?expand=1), includes additional steps (like cloning the repo) that I had to add to get this running in my bitrise account.