### PR TITLE
Remove duplicated env key validation.

### DIFF
--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -312,12 +312,9 @@ func (env *EnvironmentItemModel) FillMissingDefaults() error {
 
 // Validate ...
 func (env EnvironmentItemModel) Validate() error {
-	key, _, err := env.GetKeyValuePair()
+	_, _, err := env.GetKeyValuePair()
 	if err != nil {
 		return err
-	}
-	if key == "" {
-		return errors.New("no environment key found")
 	}
 	_, err = env.GetOptions()
 	if err != nil {


### PR DESCRIPTION
### Context

Remove duplicated env var key empty check from `EnvironmentItemModel.Validate`.
Func Validate calls `env.GetKeyValuePair`, which already validates if the env var key is not empty.

### Changes

- Remove duplicated env var key empty check from `EnvironmentItemModel.Validate`.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
