### PR TITLE
Moved utils to cli package

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -64,7 +64,7 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 
 func addEnv(key string, value string, expand, replace, skipIfEmpty, sensitive bool) error {
 	// Load envs, or create if not exist
-	environments, err := envman.ReadEnvsOrCreateEmptyList()
+	environments, err := ReadEnvsOrCreateEmptyList()
 	if err != nil {
 		return err
 	}
@@ -89,12 +89,12 @@ func addEnv(key string, value string, expand, replace, skipIfEmpty, sensitive bo
 		return err
 	}
 
-	newEnvSlice, err := envman.UpdateOrAddToEnvlist(environments, newEnv, replace)
+	newEnvSlice, err := UpdateOrAddToEnvlist(environments, newEnv, replace)
 	if err != nil {
 		return err
 	}
 
-	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, newEnvSlice)
+	return WriteEnvMapToFile(CurrentEnvStoreFilePath, newEnvSlice)
 }
 
 func loadValueFromFile(pth string) (string, error) {
@@ -108,7 +108,7 @@ func loadValueFromFile(pth string) (string, error) {
 }
 
 func logEnvs() error {
-	environments, err := envman.ReadEnvs(envman.CurrentEnvStoreFilePath)
+	environments, err := ReadEnvs(CurrentEnvStoreFilePath)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func logEnvs() error {
 }
 
 func add(c *cli.Context) error {
-	log.Debugln("[ENVMAN] Work path:", envman.CurrentEnvStoreFilePath)
+	log.Debugln("[ENVMAN] Work path:", CurrentEnvStoreFilePath)
 
 	key := c.String(KeyKey)
 	expand := !c.Bool(NoExpandKey)
@@ -192,7 +192,7 @@ func add(c *cli.Context) error {
 			}
 
 			if configs.EnvListBytesLimitInKB > 0 {
-				envList, err := envman.ReadEnvsOrCreateEmptyList()
+				envList, err := ReadEnvsOrCreateEmptyList()
 				if err != nil {
 					log.Fatalf("[ENVMAN] failed to get env list, error: %s", err)
 				}

--- a/cli/clear.go
+++ b/cli/clear.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 
-	"github.com/bitrise-io/envman/envman"
 	"github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-utils/pathutil"
 	log "github.com/sirupsen/logrus"
@@ -11,18 +10,18 @@ import (
 )
 
 func clearEnvs() error {
-	if isExists, err := pathutil.IsPathExists(envman.CurrentEnvStoreFilePath); err != nil {
+	if isExists, err := pathutil.IsPathExists(CurrentEnvStoreFilePath); err != nil {
 		return err
 	} else if !isExists {
-		errMsg := "EnvStore not found in path:" + envman.CurrentEnvStoreFilePath
+		errMsg := "EnvStore not found in path:" + CurrentEnvStoreFilePath
 		return errors.New(errMsg)
 	}
 
-	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, []models.EnvironmentItemModel{})
+	return WriteEnvMapToFile(CurrentEnvStoreFilePath, []models.EnvironmentItemModel{})
 }
 
 func clear(c *cli.Context) error {
-	log.Debugln("[ENVMAN] - Work path:", envman.CurrentEnvStoreFilePath)
+	log.Debugln("[ENVMAN] - Work path:", CurrentEnvStoreFilePath)
 
 	if err := clearEnvs(); err != nil {
 		log.Fatal("[ENVMAN] - Failed to clear EnvStore:", err)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -48,17 +48,17 @@ func before(c *cli.Context) error {
 
 	// Befor parsing cli, and running command
 	// we need to decide wich path will be used by envman
-	envman.CurrentEnvStoreFilePath = c.String(PathKey)
-	if envman.CurrentEnvStoreFilePath == "" {
+	CurrentEnvStoreFilePath = c.String(PathKey)
+	if CurrentEnvStoreFilePath == "" {
 		if path, err := filepath.Abs(path.Join("./", defaultEnvStoreName)); err != nil {
 			log.Fatal("[ENVMAN] - Failed to set envman work path in current dir:", err)
 		} else {
-			envman.CurrentEnvStoreFilePath = path
+			CurrentEnvStoreFilePath = path
 		}
 	}
 
-	envman.ToolMode = c.Bool(ToolKey)
-	if envman.ToolMode {
+	ToolMode = c.Bool(ToolKey)
+	if ToolMode {
 		log.Info("[ENVMAN] - Tool mode on")
 	}
 

--- a/cli/init.go
+++ b/cli/init.go
@@ -1,23 +1,22 @@
 package cli
 
 import (
-	"github.com/bitrise-io/envman/envman"
 	"github.com/bitrise-io/go-utils/command"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
 func initEnvStore(c *cli.Context) error {
-	log.Debugln("[ENVMAN] - Work path:", envman.CurrentEnvStoreFilePath)
+	log.Debugln("[ENVMAN] - Work path:", CurrentEnvStoreFilePath)
 
 	clear := c.Bool(ClearKey)
 	if clear {
-		if err := command.RemoveFile(envman.CurrentEnvStoreFilePath); err != nil {
+		if err := command.RemoveFile(CurrentEnvStoreFilePath); err != nil {
 			log.Fatal("[ENVMAN] - Failed to clear path:", err)
 		}
 	}
 
-	if err := envman.InitAtPath(envman.CurrentEnvStoreFilePath); err != nil {
+	if err := InitAtPath(CurrentEnvStoreFilePath); err != nil {
 		log.Fatal("[ENVMAN] - Failed to init at path:", err)
 	}
 

--- a/cli/print.go
+++ b/cli/print.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bitrise-io/envman/envman"
 	"github.com/bitrise-io/envman/models"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -74,7 +73,7 @@ func print(c *cli.Context) error {
 	sensitiveOnly := c.Bool(SensitiveOnlyKey)
 
 	// Read envs
-	environments, err := envman.ReadEnvs(envman.CurrentEnvStoreFilePath)
+	environments, err := ReadEnvs(CurrentEnvStoreFilePath)
 	if err != nil {
 		log.Fatalf("Failed to read envs, error: %s", err)
 	}

--- a/cli/print_test.go
+++ b/cli/print_test.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/bitrise-io/envman/envman"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +14,7 @@ envs:
 - TEST_HOME1: $HOME
 - TEST_HOME2: $TEST_HOME1/test
 `
-	environments, err := envman.ParseEnvsYML([]byte(envsStr))
+	environments, err := ParseEnvsYML([]byte(envsStr))
 	require.Equal(t, nil, err)
 
 	envsJSONList, err := convertToEnvsJSONModel(environments, false, false)
@@ -39,7 +38,7 @@ envs:
   opts:
     is_sensitive: true
 `
-	environments, err := envman.ParseEnvsYML([]byte(envsStr))
+	environments, err := ParseEnvsYML([]byte(envsStr))
 	require.Equal(t, nil, err)
 
 	// print everything

--- a/cli/run.go
+++ b/cli/run.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/bitrise-io/envman/env"
-	"github.com/bitrise-io/envman/envman"
 	"github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-utils/command"
 	log "github.com/sirupsen/logrus"
@@ -47,10 +46,10 @@ func runCommandModel(cmdModel CommandModel) (int, error) {
 }
 
 func run(c *cli.Context) error {
-	log.Debug("[ENVMAN] - Work path:", envman.CurrentEnvStoreFilePath)
+	log.Debug("[ENVMAN] - Work path:", CurrentEnvStoreFilePath)
 
 	if len(c.Args()) > 0 {
-		doCmdEnvs, err := envman.ReadEnvs(envman.CurrentEnvStoreFilePath)
+		doCmdEnvs, err := ReadEnvs(CurrentEnvStoreFilePath)
 		if err != nil {
 			log.Fatal("[ENVMAN] - Failed to load EnvStore:", err)
 		}

--- a/cli/unset.go
+++ b/cli/unset.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"github.com/bitrise-io/envman/envman"
 	"github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-utils/pointers"
 	"github.com/urfave/cli"
@@ -10,7 +9,7 @@ import (
 func unset(c *cli.Context) error {
 	key := c.String(KeyKey)
 	// Load envs, or create if not exist
-	environments, err := envman.ReadEnvsOrCreateEmptyList()
+	environments, err := ReadEnvsOrCreateEmptyList()
 	if err != nil {
 		return err
 	}
@@ -27,10 +26,10 @@ func unset(c *cli.Context) error {
 		return err
 	}
 
-	newEnvSlice, err := envman.UpdateOrAddToEnvlist(environments, newEnv, true)
+	newEnvSlice, err := UpdateOrAddToEnvlist(environments, newEnv, true)
 	if err != nil {
 		return err
 	}
 
-	return envman.WriteEnvMapToFile(envman.CurrentEnvStoreFilePath, newEnvSlice)
+	return WriteEnvMapToFile(CurrentEnvStoreFilePath, newEnvSlice)
 }

--- a/cli/util.go
+++ b/cli/util.go
@@ -1,4 +1,4 @@
-package envman
+package cli
 
 import (
 	"errors"

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -1,4 +1,4 @@
-package envman
+package cli
 
 import (
 	"testing"


### PR DESCRIPTION
Removes the _go-inp_ package as a dependency of _envman_. This resulted in `x/sys` added as a dependency in code that does not use it and old versions of `x/sys` do not compile with go 1.18. (See https://github.com/golang/go/issues/49219)

Changes:
- Moved utils.go from the envman package to the cli package, as it is the only place it is used from.