### PR TITLE
Use Goreleaser to publish releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _tmp/
 _bin/
 .gows.user.yml
 .idea
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,66 @@
+before:
+  hooks:
+  - go mod tidy
+
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  goarch:
+  - amd64
+  - arm64
+  ignore:
+  # We don't want to publish a linux-arm64 binary
+  - goos: linux
+    goarch: arm64
+  ldflags:
+  - -X github.com/bitrise-io/envman/version.Commit={{ .FullCommit }}
+  - -X github.com/bitrise-io/envman/version.BuildNumber={{ index .Env "BITRISE_BUILD_NUMBER" }}
+
+archives:
+# GitHub release should contain the raw binaries (no zip or tar.gz)
+- format: binary
+  # Name format should match the curl install script
+  name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    amd64: x86_64
+
+release:
+  github:
+    owner: bitrise-io
+    name: envman
+  draft: true
+  mode: replace
+  footer: |
+    ### Install or upgrade
+
+    To install this version, run the following command (in a bash shell):
+    
+      ```bash
+      curl -fL https://github.com/bitrise-io/{{ .ProjectName }}/releases/download/{{ .Tag }}/{{ .ProjectName }}-"$(uname -s)"-"$(uname -m)" > /usr/local/bin/{{ .ProjectName }}
+      ```
+    ℹ️ M1 machine: Please note by default `/usr/local/bin` does not exist on M1 machines and isn't encouraged by the community over `/opt/bin`. Use a custom folder path or use your own `bin` folder path. i.e `/opt/bin`
+    
+    Then:
+    
+      ```
+      chmod +x /usr/local/bin/{{ .ProjectName }}
+      ```
+    
+      That's all, you're ready to call `{{ .ProjectName }}`!
+
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  # Run `goreleaser release --snapshot` locally to create binaries without publishing and checks
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: "5"
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: other
 
@@ -10,10 +10,10 @@ workflows:
   test:
     title: Runs tests
     steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
+    - go-list: { }
+    - golint: { }
+    - errcheck: { }
+    - go-test: { }
     - codecov:
         run_if: .IsCI
         inputs:
@@ -27,6 +27,7 @@ workflows:
             set -ex
 
             current_envman="$(pwd)/_tmp/test_envman"
+            export CGO_ENABLED=0
             go build -o "$current_envman"
 
             export PR="" PULL_REQUEST_ID=""
@@ -37,65 +38,34 @@ workflows:
             unset content
             go test -v ./_tests/integration/...
 
-  create-binaries:
-    title: Create binaries
+  create-release:
+    description: Creates Linux and Darwin binaries, then publishes a GitHub release
+    envs:
+    - GITHUB_TOKEN: $GIT_BOT_USER_ACCESS_TOKEN # Goreleaser expects this env var
     steps:
     - script:
-        title: Create binaries
+        title: Goreleaser (create binaries + publish to GH)
+        deps:
+          brew:
+          - name: goreleaser
         inputs:
         - content: |
-            #!/bin/bash
+            #!/usr/bin/env bash
             set -ex
 
-            echo
-            echo "Create final binaries"
-            echo "  Build number: $BITRISE_BUILD_NUMBER"
+            goreleaser release
 
-            export ARCH=x86_64
-            export GOARCH=amd64
-
-            # Create Darwin bin
-            export OS=Darwin
-            export GOOS=darwin
-
-            DEPLOY_PATH="_bin/$BIN_NAME-$OS-$ARCH"
-            echo "  Create final Darwin binary at: $DEPLOY_PATH"
-
-            version_package="github.com/bitrise-io/envman/version"
-
-            go build \
-              -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
-              -o "$DEPLOY_PATH"
-
-            envman add --key OSX_DEPLOY_PATH --value $DEPLOY_PATH
-            cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
-            echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
-
-
-            # Create Linux binary
-            export OS=Linux
-            export GOOS=linux
-
-            DEPLOY_PATH="_bin/$BIN_NAME-$OS-$ARCH"
-            echo "  Create final Linux binary at: $DEPLOY_PATH"
-
-            go build \
-              -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
-              -o "$DEPLOY_PATH"
-
-            envman add --key LINUX_DEPLOY_PATH --value $DEPLOY_PATH
-            cp $DEPLOY_PATH $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH
-            echo "  Copy final Linux binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$OS-$ARCH"
-
-  dep-update:
-    title: Dep update
+  test-binary-build:
+    description: Tests the release build process by creating a snapshot release (without publishing)
     steps:
     - script:
-        title: Dependency update
+        title: Goreleaser (create snapshot binaries)
+        deps:
+          brew:
+          - name: goreleaser
         inputs:
-        - content: |-
-            #!/bin/bash
+        - content: |
+            #!/usr/bin/env bash
             set -ex
-            go get -u -v github.com/golang/dep/cmd/dep
-            dep ensure -v
-            dep ensure -v -update
+
+            goreleaser release --snapshot --rm-dist

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
-// BuildNumber ...
+// BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""
 
-// Commit ...
+// Commit is the git commit hash used for building the release. It's defined at build time using -ldflags
 var Commit = ""


### PR DESCRIPTION
### Context

Use [Goreleaser](https://goreleaser.com/) for building the release binaries of envman. The current bash scripts and workflows that build and publish the binaries to GitHub are error prone and the entire release workflow is defined at multiple places (`bitrise.yml` in the repo, Bitrise project of envman, the `tooling-control-center` project).

This PR simplifies the workflow and defines the entire process as source files in the repo (so that we can keep track of changes)

### Changes

- Create Goreleaser config file as `.goreleaser.yml`
- Build arm64 and amd64 binaries for Linux and macOS (just like before)
- Use Goreleaser to create the changelog and publish a GitHub release. This was previously defined in the `tooling-control-center` workflow
- Test the release process in the PR validation workflow by creating a snapshot release (without publishing)