### PR TITLE
Use automatic version numbers in release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,7 @@ builds:
   - goos: linux
     goarch: arm64
   ldflags:
+  - -X github.com/bitrise-io/envman/version.Version={{ .Version }}
   - -X github.com/bitrise-io/envman/version.Commit={{ .FullCommit }}
   - -X github.com/bitrise-io/envman/version.BuildNumber={{ index .Env "BITRISE_BUILD_NUMBER" }}
 
@@ -23,11 +24,11 @@ archives:
 # GitHub release should contain the raw binaries (no zip or tar.gz)
 - format: binary
   # Name format should match the curl install script
-  name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    amd64: x86_64
+  name_template: >-
+    {{ .ProjectName }}-
+    {{- title .Os }}-
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else }}{{ .Arch }}{{ end }}
 
 release:
   github:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -81,7 +81,7 @@ func Run() {
 	app := cli.NewApp()
 	app.Name = path.Base(os.Args[0])
 	app.Usage = "Environment variable manager"
-	app.Version = version.VERSION
+	app.Version = version.Version
 
 	app.Author = ""
 	app.Email = ""

--- a/cli/version.go
+++ b/cli/version.go
@@ -24,7 +24,7 @@ func printVersionCmd(c *cli.Context) error {
 	}
 
 	versionOutput := VersionOutputModel{
-		Version: version.VERSION,
+		Version: version.Version,
 	}
 
 	if fullVersion {

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-// VERSION ...
-const VERSION = "2.4.0"
+// Version is the main CLI version number. It's defined at build time using -ldflags
+var Version = "0.99-development"


### PR DESCRIPTION
For some reason, this repo was still using hardcoded version strings (while all other binary tool repos use Goreleaser and `-ldflags`.

This PR aligns the release config to what we have in other repos.