### PR TITLE
Feat: add export command to make output evaluable for shell

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,6 +1,10 @@
 package cli
 
-import "github.com/urfave/cli"
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
 
 const (
 	// PathEnvKey ...
@@ -69,6 +73,8 @@ const (
 	OutputFormatRaw = "raw"
 	// OutputFormatJSON ...
 	OutputFormatJSON = "json"
+	// OutputFormatExport
+	OutputFormatEnvList = "envlist"
 )
 
 var (
@@ -123,7 +129,7 @@ var (
 	}
 	flFormat = cli.StringFlag{
 		Name:  FormatKey,
-		Usage: "Output format (options: raw, json).",
+		Usage: fmt.Sprintf("Output format (options: %s, %s, %s).", OutputFormatRaw, OutputFormatJSON, OutputFormatEnvList),
 	}
 	flExpand = cli.BoolFlag{
 		Name:  ExpandKey,

--- a/cli/print.go
+++ b/cli/print.go
@@ -15,7 +15,7 @@ func printCmd(c *cli.Context) error {
 	format := c.String(FormatKey)
 	if format == "" {
 		format = OutputFormatRaw
-	} else if !(format == OutputFormatRaw || format == OutputFormatJSON) {
+	} else if !(format == OutputFormatRaw || format == OutputFormatJSON || format == OutputFormatEnvList) {
 		log.Fatalf("Invalid format: %s", format)
 	}
 
@@ -32,6 +32,8 @@ func printCmd(c *cli.Context) error {
 	switch format {
 	case OutputFormatRaw:
 		printRawEnvs(envSet)
+	case OutputFormatEnvList:
+		printEnvsList(envSet)
 	case OutputFormatJSON:
 		if err := printJSONEnvs(envSet); err != nil {
 			log.Fatalf("Failed to print env list, err: %s", err)
@@ -113,6 +115,14 @@ func printRawEnvs(envList models.EnvsJSONListModel) {
 	fmt.Println()
 	for key, value := range envList {
 		fmt.Printf("%s: %s\n", key, value)
+	}
+	fmt.Println()
+}
+
+func printEnvsList(envList models.EnvsJSONListModel) {
+	fmt.Println()
+	for key, value := range envList {
+		fmt.Printf("export %s=%q\n", key, value)
 	}
 	fmt.Println()
 }


### PR DESCRIPTION
This PR follow #185 in order to allow people to evaluate content of envman store for shell.
It makes it easy to managed user profile environment variable.

Usage example:

`eval $(envman export [--expand] --format envlist)`

Here result of differents values

```
$ cat ~/.envstore.yml
envs:
- EXPAND: ${PWD}
- TEST_QUOTE: '"HYU"'
- TEST_QUOTE_EXPAND: '"$PWD"'
- TEST_QUOTE_EXPAND_1: '"${PWD}"'
- TEST_QUOTE_EXPAND_2: '"${TEST_QUOTE}"'

$ ./opensource/envman/main print --format envlist

export TEST_QUOTE_EXPAND="\"$PWD\""
export TEST_QUOTE_EXPAND_1="\"${PWD}\""
export TEST_QUOTE_EXPAND_2="\"${TEST_QUOTE}\""
export EXPAND="${PWD}"
export TEST_QUOTE="\"HYU\""


$ ./opensource/envman/main print --format envlist --expand

export EXPAND="/home/jynolen"
export TEST_QUOTE="\"HYU\""
export TEST_QUOTE_EXPAND="\"/home/jynolen\""
export TEST_QUOTE_EXPAND_1="\"/home/jynolen\""
export TEST_QUOTE_EXPAND_2="\"\"HYU\"\""


```