### PR TITLE
Make convertToEnvsJSONModel exported

### DIFF
--- a/cli/print.go
+++ b/cli/print.go
@@ -50,10 +50,10 @@ func ReadEnvsJSONList(envStorePth string, expand, sensitiveOnly bool, envSource 
 		return nil, fmt.Errorf("failed to read envs: %s", err)
 	}
 
-	return convertToEnvsJSONModel(envs, expand, sensitiveOnly, envSource)
+	return ConvertToEnvsJSONModel(envs, expand, sensitiveOnly, envSource)
 }
 
-func convertToEnvsJSONModel(envs []models.EnvironmentItemModel, expand, sensitiveOnly bool, envSource env.EnvironmentSource) (models.EnvsJSONListModel, error) {
+func ConvertToEnvsJSONModel(envs []models.EnvironmentItemModel, expand, sensitiveOnly bool, envSource env.EnvironmentSource) (models.EnvsJSONListModel, error) {
 	if sensitiveOnly {
 		var err error
 		envs, err = sensitiveEnvs(envs)

--- a/cli/print_test.go
+++ b/cli/print_test.go
@@ -18,14 +18,14 @@ envs:
 	environments, err := ParseEnvsYML([]byte(envsStr))
 	require.Equal(t, nil, err)
 
-	envsJSONList, err := convertToEnvsJSONModel(environments, false, false, &env.DefaultEnvironmentSource{})
+	envsJSONList, err := ConvertToEnvsJSONModel(environments, false, false, &env.DefaultEnvironmentSource{})
 	require.Equal(t, nil, err)
 	require.Equal(t, "$HOME", envsJSONList["TEST_HOME1"])
 	require.Equal(t, "$TEST_HOME1/test", envsJSONList["TEST_HOME2"])
 
 	testHome1 := os.Getenv("HOME")
 	testHome2 := path.Join(testHome1, "test")
-	envsJSONList, err = convertToEnvsJSONModel(environments, true, false, &env.DefaultEnvironmentSource{})
+	envsJSONList, err = ConvertToEnvsJSONModel(environments, true, false, &env.DefaultEnvironmentSource{})
 	require.Equal(t, nil, err)
 	require.Equal(t, testHome1, envsJSONList["TEST_HOME1"])
 	require.Equal(t, testHome2, envsJSONList["TEST_HOME2"])
@@ -43,13 +43,13 @@ envs:
 	require.Equal(t, nil, err)
 
 	// print everything
-	envsJSONList, err := convertToEnvsJSONModel(environments, false, false, &env.DefaultEnvironmentSource{})
+	envsJSONList, err := ConvertToEnvsJSONModel(environments, false, false, &env.DefaultEnvironmentSource{})
 	require.Equal(t, nil, err)
 	require.Equal(t, "testvalue", envsJSONList["nonsensitivekey"])
 	require.Equal(t, "testsecret", envsJSONList["sensitivekey"])
 
 	// print sensitive only
-	envsJSONList, err = convertToEnvsJSONModel(environments, true, true, &env.DefaultEnvironmentSource{})
+	envsJSONList, err = ConvertToEnvsJSONModel(environments, true, true, &env.DefaultEnvironmentSource{})
 	require.Equal(t, nil, err)
 	require.Equal(t, "", envsJSONList["nonsensitivekey"])
 	require.Equal(t, "testsecret", envsJSONList["sensitivekey"])


### PR DESCRIPTION
This PR exposes the `ConvertToEnvsJSONModel`, so that consumers can convert an `models.EnvironmentItemModel` list into `models.EnvsJSONListModel`, without writing it to an EnvStore file and reading them again as an `EnvsJSONList`.