### PR TITLE
Introduce dedicated error types for env var and env var list validation

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 
@@ -162,8 +161,8 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 	valueSizeInBytes := len([]byte(value))
 	if configs.EnvBytesLimitInKB > 0 {
 		if valueSizeInBytes > configs.EnvBytesLimitInKB*1024 {
-			valueSizeInKB := ((float64)(valueSizeInBytes)) / 1024.0
-			return fmt.Sprintf("environment var (%s) value is too large (%#v KB), max allowed size: %#v KB", key, valueSizeInKB, (float64)(configs.EnvBytesLimitInKB)), nil
+			valueSizeInKB := (float64)(valueSizeInBytes) / 1024.0
+			return "", NewEnvVarValueTooLargeError(key, valueSizeInKB, (float64)(configs.EnvBytesLimitInKB))
 		}
 	}
 
@@ -174,7 +173,7 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 		}
 		if envListSizeInBytes+valueSizeInBytes > configs.EnvListBytesLimitInKB*1024 {
 			listSizeInKB := (float64)(envListSizeInBytes)/1024 + (float64)(valueSizeInBytes)/1024
-			return "", fmt.Errorf("environment list is too large (%#v KB), max allowed size: %#v KB", listSizeInKB, (float64)(configs.EnvListBytesLimitInKB))
+			return "", NewEnvVarListTooLargeError(listSizeInKB, (float64)(configs.EnvListBytesLimitInKB))
 		}
 	}
 	return value, nil

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -33,5 +33,5 @@ func NewEnvVarListTooLargeError(envListSizeInKB, maxSizeInKB float64) EnvVarList
 }
 
 func (e EnvVarListTooLargeError) Error() string {
-	return fmt.Sprintf("environment list is too large (%#v KB), max allowed size: %#v KB", e.EnvListSizeInKB, e.MaxSizeInKB)
+	return fmt.Sprintf("env var list is too large (%#v KB), max allowed size: %#v KB", e.EnvListSizeInKB, e.MaxSizeInKB)
 }

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,0 +1,37 @@
+package cli
+
+import "fmt"
+
+type EnvVarValueTooLargeError struct {
+	Key           string
+	ValueSizeInKB float64
+	MaxSizeInKB   float64
+}
+
+func NewEnvVarValueTooLargeError(key string, valueSizeInKB, maxSizeInKB float64) error {
+	return EnvVarValueTooLargeError{
+		Key:           key,
+		ValueSizeInKB: valueSizeInKB,
+		MaxSizeInKB:   maxSizeInKB,
+	}
+}
+
+func (err EnvVarValueTooLargeError) Error() string {
+	return fmt.Sprintf("env var (%s) value is too large (%#v KB), max allowed size: %#v KB", err.Key, err.ValueSizeInKB, err.MaxSizeInKB)
+}
+
+type EnvVarListTooLargeError struct {
+	EnvListSizeInKB float64
+	MaxSizeInKB     float64
+}
+
+func NewEnvVarListTooLargeError(envListSizeInKB, maxSizeInKB float64) EnvVarListTooLargeError {
+	return EnvVarListTooLargeError{
+		EnvListSizeInKB: envListSizeInKB,
+		MaxSizeInKB:     maxSizeInKB,
+	}
+}
+
+func (e EnvVarListTooLargeError) Error() string {
+	return fmt.Sprintf("environment list is too large (%#v KB), max allowed size: %#v KB", e.EnvListSizeInKB, e.MaxSizeInKB)
+}


### PR DESCRIPTION
This PR introduces dedicated error types for `EnvVarValueTooLargeError` and `EnvVarListTooLargeError` to allow the Bitrise CLI to suggest [resolutions for these issues](https://support.bitrise.io/en/articles/9676692-envman-environment-list-too-large-error).