### PR TITLE
Fix tool-versions pinned go version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22
+golang 1.21.13


### PR DESCRIPTION
This PR sets Go version to 1.21.13  .tool-versions [similar to the Bitrise CLI](https://github.com/bitrise-io/bitrise/blob/master/.tool-versions).