### PR TITLE
Remove duplicated env var limit validation and improve error messages

### DIFF
--- a/_tests/integration/add_test.go
+++ b/_tests/integration/add_test.go
@@ -129,7 +129,8 @@ func TestAdd(t *testing.T) {
 
 		out, err := addPipeCommand("KEY", strings.NewReader(strings.Repeat("0", 2*1024)), envstore).RunAndReturnTrimmedCombinedOutput()
 		require.Error(t, err)
-		require.True(t, strings.Contains(out, "environment value size (2 KB) - max allowed size: 1 KB"))
+		require.True(t, strings.Contains(out, `[ENVMAN] Failed to add env var: env var (KEY) value is too large (2 KB), max allowed size: 1 KB.
+To increase env var limits please visit: https://support.bitrise.io/en/articles/9676692-env-var-value-too-large-env-var-list-too-large`), out)
 
 		if exists {
 			require.NoError(t, fileutil.WriteBytesToFile(configPath, origData))

--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -18,7 +18,7 @@ func binPath() string {
 		if os.Getenv("CI") == "true" {
 			panic("INTEGRATION_TEST_BINARY_PATH env is required in CI")
 		} else {
-			log.Warn("INTEGRATION_TEST_BINARY_PATH is not set, make sure 'bitrise' binary in your PATH is up-to-date")
+			log.Warn("INTEGRATION_TEST_BINARY_PATH is not set, make sure 'envman' binary in your PATH is up-to-date")
 			pth = "envman"
 		}
 	}

--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -1,7 +1,27 @@
 package integration
 
-import "os"
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var binPathStr string
 
 func binPath() string {
-	return os.Getenv("INTEGRATION_TEST_BINARY_PATH")
+	if binPathStr != "" {
+		return binPathStr
+	}
+
+	pth := os.Getenv("INTEGRATION_TEST_BINARY_PATH")
+	if pth == "" {
+		if os.Getenv("CI") == "true" {
+			panic("INTEGRATION_TEST_BINARY_PATH env is required in CI")
+		} else {
+			log.Warn("INTEGRATION_TEST_BINARY_PATH is not set, make sure 'bitrise' binary in your PATH is up-to-date")
+			pth = "envman"
+		}
+	}
+	binPathStr = pth
+	return pth
 }


### PR DESCRIPTION
This PR updates the env var limits exceeded-related error messages. The new errors will link to the related Knowledge Base article.