### PR TITLE
Bump envman version to 2.5.3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the main CLI version number. It's defined at build time using -ldflags
-var Version = "2.5.2"
+var Version = "2.5.3"


### PR DESCRIPTION
This PR updates envman version to 2.5.3, to release:
- https://github.com/bitrise-io/envman/pull/232