### PR TITLE
Allow overriding env byte limits via environment variables

### DIFF
--- a/envman/configs.go
+++ b/envman/configs.go
@@ -2,8 +2,10 @@ package envman
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -13,6 +15,11 @@ const (
 	envmanConfigFileName         = "configs.json"
 	defaultEnvBytesLimitInKB     = 256
 	defaultEnvListBytesLimitInKB = 256
+
+	// Environment variables to override the byte limits, take precedence over the config file.
+	// Useful when the config file is not writable/reachable, e.g. while running a script step.
+	envBytesLimitInKBEnvKey     = "ENVMAN_ENV_BYTES_LIMIT_IN_KB"
+	envListBytesLimitInKBEnvKey = "ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB"
 )
 
 // ConfigsModel ...
@@ -50,37 +57,63 @@ func createDefaultConfigsModel() ConfigsModel {
 // GetConfigs ...
 func GetConfigs() (ConfigsModel, error) {
 	configPth := getEnvmanConfigsFilePath()
-	defaultConfigs := createDefaultConfigsModel()
+	configs := createDefaultConfigsModel()
 
-	if isExist, err := pathutil.IsPathExists(configPth); err != nil {
-		return ConfigsModel{}, err
-	} else if !isExist {
-		return defaultConfigs, nil
-	}
-
-	bytes, err := fileutil.ReadBytesFromFile(configPth)
+	isExist, err := pathutil.IsPathExists(configPth)
 	if err != nil {
 		return ConfigsModel{}, err
 	}
 
-	type ConfigsFileMode struct {
-		EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
-		EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
+	if isExist {
+		bytes, err := fileutil.ReadBytesFromFile(configPth)
+		if err != nil {
+			return ConfigsModel{}, err
+		}
+
+		type ConfigsFileMode struct {
+			EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
+			EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
+		}
+
+		var userConfigs ConfigsFileMode
+		if err := json.Unmarshal(bytes, &userConfigs); err != nil {
+			return ConfigsModel{}, err
+		}
+
+		if userConfigs.EnvBytesLimitInKB != nil {
+			configs.EnvBytesLimitInKB = *userConfigs.EnvBytesLimitInKB
+		}
+		if userConfigs.EnvListBytesLimitInKB != nil {
+			configs.EnvListBytesLimitInKB = *userConfigs.EnvListBytesLimitInKB
+		}
 	}
 
-	var userConfigs ConfigsFileMode
-	if err := json.Unmarshal(bytes, &userConfigs); err != nil {
+	// Environment variables take precedence over the config file, so the limits stay
+	// overrideable even when the config file is not reachable (e.g. inside a script step).
+	if err := applyEnvVarOverrides(&configs); err != nil {
 		return ConfigsModel{}, err
 	}
 
-	if userConfigs.EnvBytesLimitInKB != nil {
-		defaultConfigs.EnvBytesLimitInKB = *userConfigs.EnvBytesLimitInKB
-	}
-	if userConfigs.EnvListBytesLimitInKB != nil {
-		defaultConfigs.EnvListBytesLimitInKB = *userConfigs.EnvListBytesLimitInKB
-	}
+	return configs, nil
+}
 
-	return defaultConfigs, nil
+// applyEnvVarOverrides overrides the limits from environment variables when set.
+func applyEnvVarOverrides(configs *ConfigsModel) error {
+	if val, ok := os.LookupEnv(envBytesLimitInKBEnvKey); ok {
+		limit, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf("invalid value (%s) for %s: %s", val, envBytesLimitInKBEnvKey, err)
+		}
+		configs.EnvBytesLimitInKB = limit
+	}
+	if val, ok := os.LookupEnv(envListBytesLimitInKBEnvKey); ok {
+		limit, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf("invalid value (%s) for %s: %s", val, envListBytesLimitInKBEnvKey, err)
+		}
+		configs.EnvListBytesLimitInKB = limit
+	}
+	return nil
 }
 
 // saveConfigs ...

--- a/envman/configs_test.go
+++ b/envman/configs_test.go
@@ -49,3 +49,67 @@ func TestGetConfigs(t *testing.T) {
 	// delete the tmp config file
 	require.NoError(t, os.Remove(configPth))
 }
+
+func TestGetConfigsEnvVarOverride(t *testing.T) {
+	// fake home, to control the configs file
+	fakeHomePth, err := pathutil.NormalizedOSTempDirPath("_FAKE_HOME")
+	require.NoError(t, err)
+	originalHome := os.Getenv("HOME")
+	defer func() {
+		require.NoError(t, os.Setenv("HOME", originalHome))
+		require.NoError(t, os.RemoveAll(fakeHomePth))
+	}()
+	require.NoError(t, os.Setenv("HOME", fakeHomePth))
+
+	unsetEnvs := func() {
+		require.NoError(t, os.Unsetenv(envBytesLimitInKBEnvKey))
+		require.NoError(t, os.Unsetenv(envListBytesLimitInKBEnvKey))
+	}
+	defer unsetEnvs()
+
+	t.Run("env vars override the defaults when no config file exists", func(t *testing.T) {
+		unsetEnvs()
+		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "111"))
+		require.NoError(t, os.Setenv(envListBytesLimitInKBEnvKey, "222"))
+
+		configs, err := GetConfigs()
+		require.NoError(t, err)
+		require.Equal(t, 111, configs.EnvBytesLimitInKB)
+		require.Equal(t, 222, configs.EnvListBytesLimitInKB)
+	})
+
+	t.Run("env vars take precedence over the config file", func(t *testing.T) {
+		unsetEnvs()
+		require.NoError(t, saveConfigs(ConfigsModel{EnvBytesLimitInKB: 123, EnvListBytesLimitInKB: 321}))
+		defer func() { require.NoError(t, os.Remove(getEnvmanConfigsFilePath())) }()
+
+		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "111"))
+		require.NoError(t, os.Setenv(envListBytesLimitInKBEnvKey, "222"))
+
+		configs, err := GetConfigs()
+		require.NoError(t, err)
+		require.Equal(t, 111, configs.EnvBytesLimitInKB)
+		require.Equal(t, 222, configs.EnvListBytesLimitInKB)
+	})
+
+	t.Run("only the set env var overrides, the other falls back to the config file", func(t *testing.T) {
+		unsetEnvs()
+		require.NoError(t, saveConfigs(ConfigsModel{EnvBytesLimitInKB: 123, EnvListBytesLimitInKB: 321}))
+		defer func() { require.NoError(t, os.Remove(getEnvmanConfigsFilePath())) }()
+
+		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "111"))
+
+		configs, err := GetConfigs()
+		require.NoError(t, err)
+		require.Equal(t, 111, configs.EnvBytesLimitInKB)
+		require.Equal(t, 321, configs.EnvListBytesLimitInKB)
+	})
+
+	t.Run("invalid env var value returns an error", func(t *testing.T) {
+		unsetEnvs()
+		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "not-a-number"))
+
+		_, err := GetConfigs()
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
The 256KB max env value and env list size limits could only be overridden via ~/.envman/configs.json. Add ENVMAN_ENV_BYTES_LIMIT_IN_KB and ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB env vars that take precedence over the config file, so the limits stay overrideable when the config file is not reachable/writable (e.g. while running a script step).