### PR TITLE
Read byte-limit overrides from envman's env list (envstore)

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -125,21 +125,21 @@ func envListSizeInBytes(envs []models.EnvironmentItemModel) (int, error) {
 	return valueSizeInBytes, nil
 }
 
-// envListLookup returns an os.LookupEnv-style resolver backed by envman's env list (envstore),
-// so config overrides can be read from the env list envman works with, not just the process env.
-func envListLookup(envList []models.EnvironmentItemModel) (func(key string) (string, bool), error) {
-	values := make(map[string]string, len(envList))
+// effectiveLimitInKB returns the byte limit to enforce: when key is set in envman's env list
+// (envstore), that value is used in place of configLimit. The override is only consulted here,
+// it is not written back into the loaded config. This keeps the limits overrideable through the
+// envstore even when envman cannot reach/write its config file (e.g. while running a script step).
+func effectiveLimitInKB(envList []models.EnvironmentItemModel, key string, configLimit int) (int, error) {
 	for _, env := range envList {
-		key, value, err := env.GetKeyValuePair()
+		envKey, envValue, err := env.GetKeyValuePair()
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
-		values[key] = value
+		if envKey == key {
+			return envman.LimitFromEnvValue(envValue, key)
+		}
 	}
-	return func(key string) (string, bool) {
-		value, ok := values[key]
-		return value, ok
-	}, nil
+	return configLimit, nil
 }
 
 func validateEnv(key, value string, envList []models.EnvironmentItemModel) (string, error) {
@@ -152,34 +152,35 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 		return "", err
 	}
 
-	// The byte limits can also be overridden through envman's own env list (envstore), which
-	// takes precedence over the config file and the process environment. This keeps the limits
-	// overrideable during a build, when the override is set as an env var rather than in the
-	// config file and envman cannot reach/write that file (e.g. while running a script step).
-	lookup, err := envListLookup(envList)
+	// The byte limits can also be overridden through envman's own env list (envstore), used in
+	// place below. The envstore override takes precedence over the loaded config, keeping the
+	// limits overrideable during a build, when the override is set as an env var rather than in
+	// the config file and envman cannot reach/write that file (e.g. while running a script step).
+	envBytesLimitInKB, err := effectiveLimitInKB(envList, envman.EnvBytesLimitInKBEnvKey, configs.EnvBytesLimitInKB)
 	if err != nil {
 		return "", err
 	}
-	if err := envman.OverrideConfigsWithEnvs(&configs, lookup); err != nil {
+	envListBytesLimitInKB, err := effectiveLimitInKB(envList, envman.EnvListBytesLimitInKBEnvKey, configs.EnvListBytesLimitInKB)
+	if err != nil {
 		return "", err
 	}
 
 	valueSizeInBytes := len([]byte(value))
-	if configs.EnvBytesLimitInKB > 0 {
-		if valueSizeInBytes > configs.EnvBytesLimitInKB*1024 {
+	if envBytesLimitInKB > 0 {
+		if valueSizeInBytes > envBytesLimitInKB*1024 {
 			valueSizeInKB := (float64)(valueSizeInBytes) / 1024.0
-			return "", NewEnvVarValueTooLargeError(key, valueSizeInKB, (float64)(configs.EnvBytesLimitInKB))
+			return "", NewEnvVarValueTooLargeError(key, valueSizeInKB, (float64)(envBytesLimitInKB))
 		}
 	}
 
-	if configs.EnvListBytesLimitInKB > 0 {
+	if envListBytesLimitInKB > 0 {
 		envListSizeInBytes, err := envListSizeInBytes(envList)
 		if err != nil {
 			return "", err
 		}
-		if envListSizeInBytes+valueSizeInBytes > configs.EnvListBytesLimitInKB*1024 {
+		if envListSizeInBytes+valueSizeInBytes > envListBytesLimitInKB*1024 {
 			listSizeInKB := (float64)(envListSizeInBytes)/1024 + (float64)(valueSizeInBytes)/1024
-			return "", NewEnvVarListTooLargeError(listSizeInKB, (float64)(configs.EnvListBytesLimitInKB))
+			return "", NewEnvVarListTooLargeError(listSizeInKB, (float64)(envListBytesLimitInKB))
 		}
 	}
 	return value, nil

--- a/cli/add.go
+++ b/cli/add.go
@@ -79,18 +79,15 @@ func add(c *cli.Context) error {
 
 // AddEnv ...
 func AddEnv(envStorePth string, key string, value string, expand, replace, skipIfEmpty, sensitive bool) error {
+	if key == "" {
+		return errors.New("key is not specified, required")
+	}
+
 	// Load envs, or create if not exist
 	environments, err := ReadEnvsOrCreateEmptyList(envStorePth)
 	if err != nil {
 		return err
 	}
-
-	// Validate input
-	validatedValue, err := validateEnv(key, value, environments)
-	if err != nil {
-		return err
-	}
-	value = validatedValue
 
 	// Add or update envlist
 	newEnv := models.EnvironmentItemModel{
@@ -110,80 +107,73 @@ func AddEnv(envStorePth string, key string, value string, expand, replace, skipI
 		return err
 	}
 
+	// Validate the resulting env list as a whole, so the byte-limit overrides apply regardless
+	// of where the override keys sit in the list.
+	if err := validateEnvList(newEnvSlice); err != nil {
+		return err
+	}
+
 	return WriteEnvMapToFile(envStorePth, newEnvSlice)
 }
 
-func envListSizeInBytes(envs []models.EnvironmentItemModel) (int, error) {
-	valueSizeInBytes := 0
-	for _, env := range envs {
-		_, value, err := env.GetKeyValuePair()
-		if err != nil {
-			return 0, err
-		}
-		valueSizeInBytes += len([]byte(value))
-	}
-	return valueSizeInBytes, nil
-}
-
-// effectiveLimitInKB returns the byte limit to enforce: when key is set in envman's env list
-// (envstore), that value is used in place of configLimit. The override is only consulted here,
-// it is not written back into the loaded config. This keeps the limits overrideable through the
-// envstore even when envman cannot reach/write its config file (e.g. while running a script step).
-func effectiveLimitInKB(envList []models.EnvironmentItemModel, key string, configLimit int) (int, error) {
-	for _, env := range envList {
-		envKey, envValue, err := env.GetKeyValuePair()
-		if err != nil {
-			return 0, err
-		}
-		if envKey == key {
-			return envman.LimitFromEnvValue(envValue, key)
-		}
-	}
-	return configLimit, nil
-}
-
-func validateEnv(key, value string, envList []models.EnvironmentItemModel) (string, error) {
-	if key == "" {
-		return "", errors.New("key is not specified, required")
-	}
-
+// validateEnvList enforces the byte limits over the whole env list. The two limit-override keys
+// (EnvBytesLimitInKBEnvKey / EnvListBytesLimitInKBEnvKey) are pulled out of the list first and
+// used in place of the configured limits, so their position in the list does not matter. The
+// remaining env vars are then validated one by one against those limits.
+func validateEnvList(envList []models.EnvironmentItemModel) error {
 	configs, err := envman.GetConfigs()
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	// The byte limits can also be overridden through envman's own env list (envstore), used in
-	// place below. The envstore override takes precedence over the loaded config, keeping the
-	// limits overrideable during a build, when the override is set as an env var rather than in
-	// the config file and envman cannot reach/write that file (e.g. while running a script step).
-	envBytesLimitInKB, err := effectiveLimitInKB(envList, envman.EnvBytesLimitInKBEnvKey, configs.EnvBytesLimitInKB)
-	if err != nil {
-		return "", err
-	}
-	envListBytesLimitInKB, err := effectiveLimitInKB(envList, envman.EnvListBytesLimitInKBEnvKey, configs.EnvListBytesLimitInKB)
-	if err != nil {
-		return "", err
-	}
+	envBytesLimitInKB := configs.EnvBytesLimitInKB
+	envListBytesLimitInKB := configs.EnvListBytesLimitInKB
 
-	valueSizeInBytes := len([]byte(value))
-	if envBytesLimitInKB > 0 {
-		if valueSizeInBytes > envBytesLimitInKB*1024 {
-			valueSizeInKB := (float64)(valueSizeInBytes) / 1024.0
-			return "", NewEnvVarValueTooLargeError(key, valueSizeInKB, (float64)(envBytesLimitInKB))
-		}
-	}
-
-	if envListBytesLimitInKB > 0 {
-		envListSizeInBytes, err := envListSizeInBytes(envList)
+	// First pass: pull the limit overrides out of the list, wherever they are.
+	for _, env := range envList {
+		key, value, err := env.GetKeyValuePair()
 		if err != nil {
-			return "", err
+			return err
 		}
-		if envListSizeInBytes+valueSizeInBytes > envListBytesLimitInKB*1024 {
-			listSizeInKB := (float64)(envListSizeInBytes)/1024 + (float64)(valueSizeInBytes)/1024
-			return "", NewEnvVarListTooLargeError(listSizeInKB, (float64)(envListBytesLimitInKB))
+		switch key {
+		case envman.EnvBytesLimitInKBEnvKey:
+			if envBytesLimitInKB, err = envman.LimitFromEnvValue(value, key); err != nil {
+				return err
+			}
+		case envman.EnvListBytesLimitInKBEnvKey:
+			if envListBytesLimitInKB, err = envman.LimitFromEnvValue(value, key); err != nil {
+				return err
+			}
 		}
 	}
-	return value, nil
+
+	// Second pass: validate every env var against the (possibly overridden) limits. The override
+	// keys themselves are config, not payload, so they are excluded from the size checks.
+	envListSizeInBytes := 0
+	for _, env := range envList {
+		key, value, err := env.GetKeyValuePair()
+		if err != nil {
+			return err
+		}
+		if key == envman.EnvBytesLimitInKBEnvKey || key == envman.EnvListBytesLimitInKBEnvKey {
+			continue
+		}
+
+		valueSizeInBytes := len([]byte(value))
+		if envBytesLimitInKB > 0 && valueSizeInBytes > envBytesLimitInKB*1024 {
+			valueSizeInKB := (float64)(valueSizeInBytes) / 1024.0
+			return NewEnvVarValueTooLargeError(key, valueSizeInKB, (float64)(envBytesLimitInKB))
+		}
+
+		envListSizeInBytes += valueSizeInBytes
+	}
+
+	if envListBytesLimitInKB > 0 && envListSizeInBytes > envListBytesLimitInKB*1024 {
+		listSizeInKB := (float64)(envListSizeInBytes) / 1024.0
+		return NewEnvVarListTooLargeError(listSizeInKB, (float64)(envListBytesLimitInKB))
+	}
+
+	return nil
 }
 
 func loadValueFromFile(pth string) (string, error) {

--- a/cli/add.go
+++ b/cli/add.go
@@ -125,6 +125,23 @@ func envListSizeInBytes(envs []models.EnvironmentItemModel) (int, error) {
 	return valueSizeInBytes, nil
 }
 
+// envListLookup returns an os.LookupEnv-style resolver backed by envman's env list (envstore),
+// so config overrides can be read from the env list envman works with, not just the process env.
+func envListLookup(envList []models.EnvironmentItemModel) (func(key string) (string, bool), error) {
+	values := make(map[string]string, len(envList))
+	for _, env := range envList {
+		key, value, err := env.GetKeyValuePair()
+		if err != nil {
+			return nil, err
+		}
+		values[key] = value
+	}
+	return func(key string) (string, bool) {
+		value, ok := values[key]
+		return value, ok
+	}, nil
+}
+
 func validateEnv(key, value string, envList []models.EnvironmentItemModel) (string, error) {
 	if key == "" {
 		return "", errors.New("key is not specified, required")
@@ -132,6 +149,18 @@ func validateEnv(key, value string, envList []models.EnvironmentItemModel) (stri
 
 	configs, err := envman.GetConfigs()
 	if err != nil {
+		return "", err
+	}
+
+	// The byte limits can also be overridden through envman's own env list (envstore), which
+	// takes precedence over the config file and the process environment. This keeps the limits
+	// overrideable during a build, when the override is set as an env var rather than in the
+	// config file and envman cannot reach/write that file (e.g. while running a script step).
+	lookup, err := envListLookup(envList)
+	if err != nil {
+		return "", err
+	}
+	if err := envman.OverrideConfigsWithEnvs(&configs, lookup); err != nil {
 		return "", err
 	}
 

--- a/cli/add_test.go
+++ b/cli/add_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -76,4 +77,39 @@ func TestValidateEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateEnvWithEnvListOverride(t *testing.T) {
+	defaultConfig, err := envman.GetConfigs()
+	require.NoError(t, err)
+
+	// A value bigger than the default per-env byte limit.
+	bigValue := strings.Repeat("a", defaultConfig.EnvBytesLimitInKB*1024+1)
+
+	t.Run("rejected without an override", func(t *testing.T) {
+		_, err := validateEnv("key", bigValue, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("accepted when the override comes from envman's env list", func(t *testing.T) {
+		// The override lives in the env list envman works with (the envstore), not in the
+		// process environment, mirroring how it is set during a build.
+		envList := []models.EnvironmentItemModel{
+			{envman.EnvBytesLimitInKBEnvKey: strconv.Itoa(defaultConfig.EnvBytesLimitInKB * 2)},
+			{envman.EnvListBytesLimitInKBEnvKey: strconv.Itoa(defaultConfig.EnvListBytesLimitInKB * 2)},
+		}
+
+		validValue, err := validateEnv("key", bigValue, envList)
+		require.NoError(t, err)
+		require.Equal(t, bigValue, validValue)
+	})
+
+	t.Run("invalid override value in the env list returns an error", func(t *testing.T) {
+		envList := []models.EnvironmentItemModel{
+			{envman.EnvBytesLimitInKBEnvKey: "not-a-number"},
+		}
+
+		_, err := validateEnv("key", "a", envList)
+		require.Error(t, err)
+	})
 }

--- a/cli/add_test.go
+++ b/cli/add_test.go
@@ -10,76 +10,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnvListSizeInBytes(t *testing.T) {
-	str100Bytes := strings.Repeat("a", 100)
-	require.Equal(t, 100, len([]byte(str100Bytes)))
-
-	env := models.EnvironmentItemModel{
-		"key": str100Bytes,
-	}
-
-	envList := []models.EnvironmentItemModel{env}
-	size, err := envListSizeInBytes(envList)
-	require.Equal(t, nil, err)
-	require.Equal(t, 100, size)
-
-	envList = []models.EnvironmentItemModel{env, env}
-	size, err = envListSizeInBytes(envList)
-	require.Equal(t, nil, err)
-	require.Equal(t, 200, size)
-}
-
-func TestValidateEnv(t *testing.T) {
+func TestValidateEnvList(t *testing.T) {
 	defaultConfig, err := envman.GetConfigs()
 	require.NoError(t, err)
 
 	tests := []struct {
 		name    string
-		key     string
-		value   string
 		envList []models.EnvironmentItemModel
 		wantErr error
 	}{
 		{
-			name:  "Max allowed env var value",
-			key:   "key",
-			value: strings.Repeat("a", defaultConfig.EnvBytesLimitInKB*1024),
+			name:    "Max allowed env var value",
+			envList: []models.EnvironmentItemModel{{"key": strings.Repeat("a", defaultConfig.EnvBytesLimitInKB*1024)}},
 		},
 		{
-			name:    "Max allowed env var list",
-			key:     "key",
-			value:   strings.Repeat("a", defaultConfig.EnvListBytesLimitInKB/2*1024),
-			envList: []models.EnvironmentItemModel{{"key": strings.Repeat("a", defaultConfig.EnvListBytesLimitInKB/2*1024)}},
+			name: "Max allowed env var list",
+			envList: []models.EnvironmentItemModel{
+				{"key1": strings.Repeat("a", defaultConfig.EnvListBytesLimitInKB/2*1024)},
+				{"key2": strings.Repeat("a", defaultConfig.EnvListBytesLimitInKB/2*1024)},
+			},
 		},
 		{
 			name:    "Too big env var value",
-			key:     "key",
-			value:   strings.Repeat("a", defaultConfig.EnvBytesLimitInKB*1024+1),
+			envList: []models.EnvironmentItemModel{{"key": strings.Repeat("a", defaultConfig.EnvBytesLimitInKB*1024+1)}},
 			wantErr: NewEnvVarValueTooLargeError("key", float64(defaultConfig.EnvBytesLimitInKB)+(1.0/1024.0), float64(defaultConfig.EnvBytesLimitInKB)),
 		},
 		{
-			name:    "Too big env var list",
-			key:     "key",
-			value:   "a",
-			envList: []models.EnvironmentItemModel{{"key": strings.Repeat("a", defaultConfig.EnvListBytesLimitInKB*1024)}},
+			name: "Too big env var list",
+			envList: []models.EnvironmentItemModel{
+				{"key1": strings.Repeat("a", defaultConfig.EnvListBytesLimitInKB*1024)},
+				{"key2": "a"},
+			},
 			wantErr: NewEnvVarListTooLargeError(((float64)(defaultConfig.EnvListBytesLimitInKB))+(float64)(len("a"))/1024.0, float64(defaultConfig.EnvListBytesLimitInKB)),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			validValue, err := validateEnv(tt.key, tt.value, tt.envList)
+			err := validateEnvList(tt.envList)
 			if tt.wantErr != nil {
 				require.Equal(t, tt.wantErr, err)
-				require.Equal(t, "", validValue)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.value, validValue)
 			}
 		})
 	}
 }
 
-func TestValidateEnvWithEnvListOverride(t *testing.T) {
+func TestValidateEnvListOverride(t *testing.T) {
 	defaultConfig, err := envman.GetConfigs()
 	require.NoError(t, err)
 
@@ -87,29 +64,28 @@ func TestValidateEnvWithEnvListOverride(t *testing.T) {
 	bigValue := strings.Repeat("a", defaultConfig.EnvBytesLimitInKB*1024+1)
 
 	t.Run("rejected without an override", func(t *testing.T) {
-		_, err := validateEnv("key", bigValue, nil)
+		err := validateEnvList([]models.EnvironmentItemModel{{"key": bigValue}})
 		require.Error(t, err)
 	})
 
-	t.Run("accepted when the override comes from envman's env list", func(t *testing.T) {
-		// The override lives in the env list envman works with (the envstore), not in the
-		// process environment, mirroring how it is set during a build.
+	t.Run("accepted when the override is anywhere in the list, even last", func(t *testing.T) {
+		// The override keys are last in the list, after the value they need to permit. They are
+		// pulled out before validation, so their position does not matter.
 		envList := []models.EnvironmentItemModel{
+			{"key": bigValue},
 			{envman.EnvBytesLimitInKBEnvKey: strconv.Itoa(defaultConfig.EnvBytesLimitInKB * 2)},
 			{envman.EnvListBytesLimitInKBEnvKey: strconv.Itoa(defaultConfig.EnvListBytesLimitInKB * 2)},
 		}
 
-		validValue, err := validateEnv("key", bigValue, envList)
-		require.NoError(t, err)
-		require.Equal(t, bigValue, validValue)
+		require.NoError(t, validateEnvList(envList))
 	})
 
-	t.Run("invalid override value in the env list returns an error", func(t *testing.T) {
+	t.Run("invalid override value returns an error", func(t *testing.T) {
 		envList := []models.EnvironmentItemModel{
+			{"key": "a"},
 			{envman.EnvBytesLimitInKBEnvKey: "not-a-number"},
 		}
 
-		_, err := validateEnv("key", "a", envList)
-		require.Error(t, err)
+		require.Error(t, validateEnvList(envList))
 	})
 }

--- a/envman/configs.go
+++ b/envman/configs.go
@@ -17,9 +17,10 @@ const (
 	defaultEnvListBytesLimitInKB = 256
 
 	// EnvBytesLimitInKBEnvKey and EnvListBytesLimitInKBEnvKey are the env keys to override the
-	// byte limits. Env-based overrides take precedence over the config file, so the limits stay
-	// overrideable when the config file is not writable/reachable, e.g. while running a script step.
-	// They are read both from the process environment and from envman's own env list (envstore).
+	// byte limits. When present in envman's env list (envstore), their values override the limits
+	// from the config file during validation, so the limits stay overrideable when the config file
+	// is not writable/reachable, e.g. while running a script step. The position of these keys in
+	// the env list does not matter; they are pulled out before the rest of the list is validated.
 	EnvBytesLimitInKBEnvKey     = "ENVMAN_ENV_BYTES_LIMIT_IN_KB"
 	EnvListBytesLimitInKBEnvKey = "ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB"
 )
@@ -90,32 +91,7 @@ func GetConfigs() (ConfigsModel, error) {
 		}
 	}
 
-	// Process environment variables take precedence over the config file, so the limits stay
-	// overrideable even when the config file is not reachable (e.g. inside a script step).
-	if err := applyEnvVarOverrides(&configs); err != nil {
-		return ConfigsModel{}, err
-	}
-
 	return configs, nil
-}
-
-// applyEnvVarOverrides overrides the byte limits from the process environment when set.
-func applyEnvVarOverrides(configs *ConfigsModel) error {
-	if val, ok := os.LookupEnv(EnvBytesLimitInKBEnvKey); ok {
-		limit, err := LimitFromEnvValue(val, EnvBytesLimitInKBEnvKey)
-		if err != nil {
-			return err
-		}
-		configs.EnvBytesLimitInKB = limit
-	}
-	if val, ok := os.LookupEnv(EnvListBytesLimitInKBEnvKey); ok {
-		limit, err := LimitFromEnvValue(val, EnvListBytesLimitInKBEnvKey)
-		if err != nil {
-			return err
-		}
-		configs.EnvListBytesLimitInKB = limit
-	}
-	return nil
 }
 
 // LimitFromEnvValue parses a byte-limit override value (in KB). key is only used for error context.

--- a/envman/configs.go
+++ b/envman/configs.go
@@ -16,10 +16,12 @@ const (
 	defaultEnvBytesLimitInKB     = 256
 	defaultEnvListBytesLimitInKB = 256
 
-	// Environment variables to override the byte limits, take precedence over the config file.
-	// Useful when the config file is not writable/reachable, e.g. while running a script step.
-	envBytesLimitInKBEnvKey     = "ENVMAN_ENV_BYTES_LIMIT_IN_KB"
-	envListBytesLimitInKBEnvKey = "ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB"
+	// EnvBytesLimitInKBEnvKey and EnvListBytesLimitInKBEnvKey are the env keys to override the
+	// byte limits. Env-based overrides take precedence over the config file, so the limits stay
+	// overrideable when the config file is not writable/reachable, e.g. while running a script step.
+	// They are read both from the process environment and from envman's own env list (envstore).
+	EnvBytesLimitInKBEnvKey     = "ENVMAN_ENV_BYTES_LIMIT_IN_KB"
+	EnvListBytesLimitInKBEnvKey = "ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB"
 )
 
 // ConfigsModel ...
@@ -88,28 +90,33 @@ func GetConfigs() (ConfigsModel, error) {
 		}
 	}
 
-	// Environment variables take precedence over the config file, so the limits stay
+	// Process environment variables take precedence over the config file, so the limits stay
 	// overrideable even when the config file is not reachable (e.g. inside a script step).
-	if err := applyEnvVarOverrides(&configs); err != nil {
+	// Overrides coming from envman's own env list (see OverrideConfigsWithEnvs) take precedence
+	// over these, as that is where the override usually lives during a build.
+	if err := OverrideConfigsWithEnvs(&configs, os.LookupEnv); err != nil {
 		return ConfigsModel{}, err
 	}
 
 	return configs, nil
 }
 
-// applyEnvVarOverrides overrides the limits from environment variables when set.
-func applyEnvVarOverrides(configs *ConfigsModel) error {
-	if val, ok := os.LookupEnv(envBytesLimitInKBEnvKey); ok {
+// OverrideConfigsWithEnvs overrides the byte limits from env values resolved by lookup.
+// lookup mirrors os.LookupEnv: it returns the value and whether the key is set. This lets the
+// limits be overridden both from the process environment and from envman's own env list (envstore),
+// which is important when envman cannot reach its config file, e.g. while running a script step.
+func OverrideConfigsWithEnvs(configs *ConfigsModel, lookup func(key string) (string, bool)) error {
+	if val, ok := lookup(EnvBytesLimitInKBEnvKey); ok {
 		limit, err := strconv.Atoi(val)
 		if err != nil {
-			return fmt.Errorf("invalid value (%s) for %s: %s", val, envBytesLimitInKBEnvKey, err)
+			return fmt.Errorf("invalid value (%s) for %s: %s", val, EnvBytesLimitInKBEnvKey, err)
 		}
 		configs.EnvBytesLimitInKB = limit
 	}
-	if val, ok := os.LookupEnv(envListBytesLimitInKBEnvKey); ok {
+	if val, ok := lookup(EnvListBytesLimitInKBEnvKey); ok {
 		limit, err := strconv.Atoi(val)
 		if err != nil {
-			return fmt.Errorf("invalid value (%s) for %s: %s", val, envListBytesLimitInKBEnvKey, err)
+			return fmt.Errorf("invalid value (%s) for %s: %s", val, EnvListBytesLimitInKBEnvKey, err)
 		}
 		configs.EnvListBytesLimitInKB = limit
 	}

--- a/envman/configs.go
+++ b/envman/configs.go
@@ -92,35 +92,39 @@ func GetConfigs() (ConfigsModel, error) {
 
 	// Process environment variables take precedence over the config file, so the limits stay
 	// overrideable even when the config file is not reachable (e.g. inside a script step).
-	// Overrides coming from envman's own env list (see OverrideConfigsWithEnvs) take precedence
-	// over these, as that is where the override usually lives during a build.
-	if err := OverrideConfigsWithEnvs(&configs, os.LookupEnv); err != nil {
+	if err := applyEnvVarOverrides(&configs); err != nil {
 		return ConfigsModel{}, err
 	}
 
 	return configs, nil
 }
 
-// OverrideConfigsWithEnvs overrides the byte limits from env values resolved by lookup.
-// lookup mirrors os.LookupEnv: it returns the value and whether the key is set. This lets the
-// limits be overridden both from the process environment and from envman's own env list (envstore),
-// which is important when envman cannot reach its config file, e.g. while running a script step.
-func OverrideConfigsWithEnvs(configs *ConfigsModel, lookup func(key string) (string, bool)) error {
-	if val, ok := lookup(EnvBytesLimitInKBEnvKey); ok {
-		limit, err := strconv.Atoi(val)
+// applyEnvVarOverrides overrides the byte limits from the process environment when set.
+func applyEnvVarOverrides(configs *ConfigsModel) error {
+	if val, ok := os.LookupEnv(EnvBytesLimitInKBEnvKey); ok {
+		limit, err := LimitFromEnvValue(val, EnvBytesLimitInKBEnvKey)
 		if err != nil {
-			return fmt.Errorf("invalid value (%s) for %s: %s", val, EnvBytesLimitInKBEnvKey, err)
+			return err
 		}
 		configs.EnvBytesLimitInKB = limit
 	}
-	if val, ok := lookup(EnvListBytesLimitInKBEnvKey); ok {
-		limit, err := strconv.Atoi(val)
+	if val, ok := os.LookupEnv(EnvListBytesLimitInKBEnvKey); ok {
+		limit, err := LimitFromEnvValue(val, EnvListBytesLimitInKBEnvKey)
 		if err != nil {
-			return fmt.Errorf("invalid value (%s) for %s: %s", val, EnvListBytesLimitInKBEnvKey, err)
+			return err
 		}
 		configs.EnvListBytesLimitInKB = limit
 	}
 	return nil
+}
+
+// LimitFromEnvValue parses a byte-limit override value (in KB). key is only used for error context.
+func LimitFromEnvValue(value, key string) (int, error) {
+	limit, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value (%s) for %s: %s", value, key, err)
+	}
+	return limit, nil
 }
 
 // saveConfigs ...

--- a/envman/configs_test.go
+++ b/envman/configs_test.go
@@ -62,15 +62,15 @@ func TestGetConfigsEnvVarOverride(t *testing.T) {
 	require.NoError(t, os.Setenv("HOME", fakeHomePth))
 
 	unsetEnvs := func() {
-		require.NoError(t, os.Unsetenv(envBytesLimitInKBEnvKey))
-		require.NoError(t, os.Unsetenv(envListBytesLimitInKBEnvKey))
+		require.NoError(t, os.Unsetenv(EnvBytesLimitInKBEnvKey))
+		require.NoError(t, os.Unsetenv(EnvListBytesLimitInKBEnvKey))
 	}
 	defer unsetEnvs()
 
 	t.Run("env vars override the defaults when no config file exists", func(t *testing.T) {
 		unsetEnvs()
-		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "111"))
-		require.NoError(t, os.Setenv(envListBytesLimitInKBEnvKey, "222"))
+		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "111"))
+		require.NoError(t, os.Setenv(EnvListBytesLimitInKBEnvKey, "222"))
 
 		configs, err := GetConfigs()
 		require.NoError(t, err)
@@ -83,8 +83,8 @@ func TestGetConfigsEnvVarOverride(t *testing.T) {
 		require.NoError(t, saveConfigs(ConfigsModel{EnvBytesLimitInKB: 123, EnvListBytesLimitInKB: 321}))
 		defer func() { require.NoError(t, os.Remove(getEnvmanConfigsFilePath())) }()
 
-		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "111"))
-		require.NoError(t, os.Setenv(envListBytesLimitInKBEnvKey, "222"))
+		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "111"))
+		require.NoError(t, os.Setenv(EnvListBytesLimitInKBEnvKey, "222"))
 
 		configs, err := GetConfigs()
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestGetConfigsEnvVarOverride(t *testing.T) {
 		require.NoError(t, saveConfigs(ConfigsModel{EnvBytesLimitInKB: 123, EnvListBytesLimitInKB: 321}))
 		defer func() { require.NoError(t, os.Remove(getEnvmanConfigsFilePath())) }()
 
-		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "111"))
+		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "111"))
 
 		configs, err := GetConfigs()
 		require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestGetConfigsEnvVarOverride(t *testing.T) {
 
 	t.Run("invalid env var value returns an error", func(t *testing.T) {
 		unsetEnvs()
-		require.NoError(t, os.Setenv(envBytesLimitInKBEnvKey, "not-a-number"))
+		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "not-a-number"))
 
 		_, err := GetConfigs()
 		require.Error(t, err)

--- a/envman/configs_test.go
+++ b/envman/configs_test.go
@@ -50,8 +50,9 @@ func TestGetConfigs(t *testing.T) {
 	require.NoError(t, os.Remove(configPth))
 }
 
-func TestGetConfigsEnvVarOverride(t *testing.T) {
-	// fake home, to control the configs file
+func TestGetConfigsIgnoresProcessEnv(t *testing.T) {
+	// The byte-limit overrides are read from envman's env list during validation, not from the
+	// process environment, so GetConfigs must ignore these env vars.
 	fakeHomePth, err := pathutil.NormalizedOSTempDirPath("_FAKE_HOME")
 	require.NoError(t, err)
 	originalHome := os.Getenv("HOME")
@@ -61,55 +62,24 @@ func TestGetConfigsEnvVarOverride(t *testing.T) {
 	}()
 	require.NoError(t, os.Setenv("HOME", fakeHomePth))
 
-	unsetEnvs := func() {
+	require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "111"))
+	require.NoError(t, os.Setenv(EnvListBytesLimitInKBEnvKey, "222"))
+	defer func() {
 		require.NoError(t, os.Unsetenv(EnvBytesLimitInKBEnvKey))
 		require.NoError(t, os.Unsetenv(EnvListBytesLimitInKBEnvKey))
-	}
-	defer unsetEnvs()
+	}()
 
-	t.Run("env vars override the defaults when no config file exists", func(t *testing.T) {
-		unsetEnvs()
-		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "111"))
-		require.NoError(t, os.Setenv(EnvListBytesLimitInKBEnvKey, "222"))
+	configs, err := GetConfigs()
+	require.NoError(t, err)
+	require.Equal(t, defaultEnvBytesLimitInKB, configs.EnvBytesLimitInKB)
+	require.Equal(t, defaultEnvListBytesLimitInKB, configs.EnvListBytesLimitInKB)
+}
 
-		configs, err := GetConfigs()
-		require.NoError(t, err)
-		require.Equal(t, 111, configs.EnvBytesLimitInKB)
-		require.Equal(t, 222, configs.EnvListBytesLimitInKB)
-	})
+func TestLimitFromEnvValue(t *testing.T) {
+	limit, err := LimitFromEnvValue("512", EnvBytesLimitInKBEnvKey)
+	require.NoError(t, err)
+	require.Equal(t, 512, limit)
 
-	t.Run("env vars take precedence over the config file", func(t *testing.T) {
-		unsetEnvs()
-		require.NoError(t, saveConfigs(ConfigsModel{EnvBytesLimitInKB: 123, EnvListBytesLimitInKB: 321}))
-		defer func() { require.NoError(t, os.Remove(getEnvmanConfigsFilePath())) }()
-
-		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "111"))
-		require.NoError(t, os.Setenv(EnvListBytesLimitInKBEnvKey, "222"))
-
-		configs, err := GetConfigs()
-		require.NoError(t, err)
-		require.Equal(t, 111, configs.EnvBytesLimitInKB)
-		require.Equal(t, 222, configs.EnvListBytesLimitInKB)
-	})
-
-	t.Run("only the set env var overrides, the other falls back to the config file", func(t *testing.T) {
-		unsetEnvs()
-		require.NoError(t, saveConfigs(ConfigsModel{EnvBytesLimitInKB: 123, EnvListBytesLimitInKB: 321}))
-		defer func() { require.NoError(t, os.Remove(getEnvmanConfigsFilePath())) }()
-
-		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "111"))
-
-		configs, err := GetConfigs()
-		require.NoError(t, err)
-		require.Equal(t, 111, configs.EnvBytesLimitInKB)
-		require.Equal(t, 321, configs.EnvListBytesLimitInKB)
-	})
-
-	t.Run("invalid env var value returns an error", func(t *testing.T) {
-		unsetEnvs()
-		require.NoError(t, os.Setenv(EnvBytesLimitInKBEnvKey, "not-a-number"))
-
-		_, err := GetConfigs()
-		require.Error(t, err)
-	})
+	_, err = LimitFromEnvValue("not-a-number", EnvBytesLimitInKBEnvKey)
+	require.Error(t, err)
 }


### PR DESCRIPTION
The ENVMAN_ENV_BYTES_LIMIT_IN_KB / ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB overrides were only read from envman's own process environment via os.LookupEnv. During a build the override is set in the env list (envstore) that envman manages, which is not necessarily exported into envman's own process env, so the override was missed.

Read the overrides from the env list passed to validateEnv as well, taking precedence over the config file and the process environment, so the limits stay overrideable through the envstore even when envman cannot reach/write its config file (e.g. while running a script step).