### PR TITLE
Add process env var overrides for env size limits

### DIFF
--- a/envman/configs.go
+++ b/envman/configs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -13,6 +14,14 @@ const (
 	envmanConfigFileName         = "configs.json"
 	defaultEnvBytesLimitInKB     = 256
 	defaultEnvListBytesLimitInKB = 256
+
+	// EnvBytesLimitInKBEnvKey and EnvListBytesLimitInKBEnvKey override the
+	// per-value and list-size limits at the process level, taking precedence
+	// over configs.json. This lets the limit be raised before the first
+	// `envman add`, which a script step cannot do because the check runs while
+	// preparing that step's own environment.
+	EnvBytesLimitInKBEnvKey     = "ENVMAN_ENV_BYTES_LIMIT_IN_KB"
+	EnvListBytesLimitInKBEnvKey = "ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB"
 )
 
 // ConfigsModel ...
@@ -47,44 +56,70 @@ func createDefaultConfigsModel() ConfigsModel {
 	}
 }
 
-// GetConfigs ...
+// GetConfigs resolves the env var limits with default < configs.json < process
+// env var precedence. A malformed or negative env override is ignored so a bad
+// value never breaks a build; the caller setting it is expected to validate.
 func GetConfigs() (ConfigsModel, error) {
 	configPth := getEnvmanConfigsFilePath()
-	defaultConfigs := createDefaultConfigsModel()
+	configs := createDefaultConfigsModel()
 
-	if isExist, err := pathutil.IsPathExists(configPth); err != nil {
-		return ConfigsModel{}, err
-	} else if !isExist {
-		return defaultConfigs, nil
-	}
-
-	bytes, err := fileutil.ReadBytesFromFile(configPth)
+	isExist, err := pathutil.IsPathExists(configPth)
 	if err != nil {
 		return ConfigsModel{}, err
 	}
 
-	type ConfigsFileMode struct {
-		EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
-		EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
+	if isExist {
+		bytes, err := fileutil.ReadBytesFromFile(configPth)
+		if err != nil {
+			return ConfigsModel{}, err
+		}
+
+		type ConfigsFileMode struct {
+			EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
+			EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
+		}
+
+		var userConfigs ConfigsFileMode
+		if err := json.Unmarshal(bytes, &userConfigs); err != nil {
+			return ConfigsModel{}, err
+		}
+
+		if userConfigs.EnvBytesLimitInKB != nil {
+			configs.EnvBytesLimitInKB = *userConfigs.EnvBytesLimitInKB
+		}
+		if userConfigs.EnvListBytesLimitInKB != nil {
+			configs.EnvListBytesLimitInKB = *userConfigs.EnvListBytesLimitInKB
+		}
 	}
 
-	var userConfigs ConfigsFileMode
-	if err := json.Unmarshal(bytes, &userConfigs); err != nil {
-		return ConfigsModel{}, err
+	if limit, ok := envLimitOverride(EnvBytesLimitInKBEnvKey); ok {
+		configs.EnvBytesLimitInKB = limit
+	}
+	if limit, ok := envLimitOverride(EnvListBytesLimitInKBEnvKey); ok {
+		configs.EnvListBytesLimitInKB = limit
 	}
 
-	if userConfigs.EnvBytesLimitInKB != nil {
-		defaultConfigs.EnvBytesLimitInKB = *userConfigs.EnvBytesLimitInKB
-	}
-	if userConfigs.EnvListBytesLimitInKB != nil {
-		defaultConfigs.EnvListBytesLimitInKB = *userConfigs.EnvListBytesLimitInKB
-	}
+	return configs, nil
+}
 
-	return defaultConfigs, nil
+// envLimitOverride reads a limit from a process env var, treating a value of 0
+// as "no limit" (matching validateEnv). Empty, non-integer, or negative values
+// return ok=false so the file/default value stands.
+func envLimitOverride(key string) (int, bool) {
+	value := os.Getenv(key)
+	if value == "" {
+		return 0, false
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit < 0 {
+		return 0, false
+	}
+	return limit, true
 }
 
 // saveConfigs ...
-//  only used for unit testing at the moment
+//
+//	only used for unit testing at the moment
 func saveConfigs(configModel ConfigsModel) error {
 	if err := ensureEnvmanConfigDirExists(); err != nil {
 		return err

--- a/envman/configs_test.go
+++ b/envman/configs_test.go
@@ -49,3 +49,70 @@ func TestGetConfigs(t *testing.T) {
 	// delete the tmp config file
 	require.NoError(t, os.Remove(configPth))
 }
+
+func TestGetConfigsEnvOverride(t *testing.T) {
+	fakeHomePth, err := pathutil.NormalizedOSTempDirPath("_FAKE_HOME")
+	require.NoError(t, err)
+	originalHome := os.Getenv("HOME")
+	t.Cleanup(func() {
+		require.NoError(t, os.Setenv("HOME", originalHome))
+		require.NoError(t, os.RemoveAll(fakeHomePth))
+	})
+	require.NoError(t, os.Setenv("HOME", fakeHomePth))
+
+	setEnvs := func(t *testing.T, envs map[string]string) {
+		for _, key := range []string{EnvBytesLimitInKBEnvKey, EnvListBytesLimitInKBEnvKey} {
+			require.NoError(t, os.Unsetenv(key))
+		}
+		for key, value := range envs {
+			require.NoError(t, os.Setenv(key, value))
+		}
+		t.Cleanup(func() {
+			for key := range envs {
+				require.NoError(t, os.Unsetenv(key))
+			}
+		})
+	}
+
+	t.Run("env override applies over defaults when no config file exists", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			EnvBytesLimitInKBEnvKey:     "512",
+			EnvListBytesLimitInKBEnvKey: "1024",
+		})
+
+		configs, err := GetConfigs()
+		require.NoError(t, err)
+		require.Equal(t, 512, configs.EnvBytesLimitInKB)
+		require.Equal(t, 1024, configs.EnvListBytesLimitInKB)
+	})
+
+	t.Run("env override wins over configs.json", func(t *testing.T) {
+		require.NoError(t, saveConfigs(ConfigsModel{EnvBytesLimitInKB: 123, EnvListBytesLimitInKB: 321}))
+		t.Cleanup(func() { require.NoError(t, os.Remove(getEnvmanConfigsFilePath())) })
+
+		setEnvs(t, map[string]string{EnvListBytesLimitInKBEnvKey: "1024"})
+
+		configs, err := GetConfigs()
+		require.NoError(t, err)
+		require.Equal(t, 123, configs.EnvBytesLimitInKB, "unset override leaves the file value")
+		require.Equal(t, 1024, configs.EnvListBytesLimitInKB, "set override replaces the file value")
+	})
+
+	t.Run("zero disables the limit", func(t *testing.T) {
+		setEnvs(t, map[string]string{EnvListBytesLimitInKBEnvKey: "0"})
+
+		configs, err := GetConfigs()
+		require.NoError(t, err)
+		require.Equal(t, 0, configs.EnvListBytesLimitInKB)
+	})
+
+	t.Run("malformed or negative override is ignored", func(t *testing.T) {
+		for _, value := range []string{"not-a-number", "-1", "12kb", ""} {
+			setEnvs(t, map[string]string{EnvListBytesLimitInKBEnvKey: value})
+
+			configs, err := GetConfigs()
+			require.NoError(t, err)
+			require.Equal(t, defaultEnvListBytesLimitInKB, configs.EnvListBytesLimitInKB, "value %q should be ignored", value)
+		}
+	})
+}


### PR DESCRIPTION
## Why

Builds fail when the assembled env var list crosses envman's list-size limit. The workflow-level mitigation (a script step that raises the limit) cannot help, because the list-size check runs while preparing that very step's own environment. A build that is already oversized on its first step has no way to lift the limit from inside the run.

The only thing that can take effect from step 0 is a value set before the CLI starts adding envs. This adds a process-level env var override so the ceiling can be raised (by DEN, or by the Bitrise CLI translating a build env into it) before the first `envman add`.

## What

`GetConfigs()` now resolves both limits with precedence:

```
default  <  configs.json  <  process env var
```

- `ENVMAN_ENV_BYTES_LIMIT_IN_KB` overrides the per-value limit.
- `ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB` overrides the list-size limit.

Fail-soft: a malformed or negative override is ignored, so a bad value never breaks a build (the caller that sets it is expected to validate and warn). A value of `0` disables the limit, matching how `validateEnv` already treats a `0` limit.

## Tests

`TestGetConfigsEnvOverride` covers: override over defaults with no file, override winning over `configs.json`, `0` disabling the limit, and malformed/negative/empty values being ignored.